### PR TITLE
fix hypot defintion

### DIFF
--- a/src/ops.jl
+++ b/src/ops.jl
@@ -10,7 +10,7 @@ const unaryOps = (:-, :~, :conj, :abs,
                   :log, :log2, :log10, :log1p, :exponent, :exp,
                   :exp2, :expm1, :cbrt, :sqrt, :erf,
                   :erfc, :erfcx, :erfi, :dawson, :ceil, :floor,
-                  :trunc, :round, :significand, :lgamma, :hypot,
+                  :trunc, :round, :significand, :lgamma,
                   :gamma, :lfact, :frexp, :modf, :airy, :airyai,
                   :airyprime, :airyaiprime, :airybi, :airybiprime,
                   :besselj0, :besselj1, :bessely0, :bessely1,
@@ -215,3 +215,5 @@ function (==)(a::FixedArray, b::AbstractArray)
 end
 
 (==)(a::AbstractArray, b::FixedArray) = b == a
+
+@inline Base.hypot{T}(v::FixedVector{2,T}) = hypot(v[1],v[2])

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -316,6 +316,14 @@ context("Ops") do
         @fact isa(cross(v1,v2),Vec3d)  --> true
     end
 
+    context("hypot") do
+        a = Vec{2,Int}(1,2)
+        b = Vec{2,Float64}(1.,2.)
+        @fact hypot(a) --> 2.23606797749979
+        @fact hypot(b) --> 2.23606797749979
+        @fact hypot(a) == hypot(b) --> true
+    end
+
 end
 
 
@@ -554,7 +562,7 @@ const unaryOps = (
     erfc, erfcx, erfi, dawson,
 
     #trunc, round, ceil, floor, #see JuliaLang/julia#12163
-    significand, lgamma, hypot,
+    significand, lgamma,
     gamma, lfact, frexp, modf, airy, airyai,
     airyprime, airyaiprime, airybi, airybiprime,
     besselj0, besselj1, bessely0, bessely1,


### PR DESCRIPTION
Hypot is not unary, so I removed it from `unaryOps`. We can just use the `Base` definition for `FixedVector` of length 2. I'd also like this in R3, but that is for the future.
