### PR TITLE
Improve codegen of `length`

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -27,8 +27,8 @@ eltype{T <: FixedArray}(A::T)                       = eltype(T)
 
 length{T,N,SZ}(A::Type{FixedArray{T,N,SZ}})         = prod(SZ.parameters)::Int
 length{T <: FixedArray}(A::Type{T})                 = length(fixedsizearray_type(T))
-length{T <: FixedArray}(A::T)                       = length(T)
-
+length{C,T}(::FixedVector{C,T})                     = C
+length{R,C,T}(::FixedMatrix{R,C,T})                 = R*C
 
 endof{T,N,SZ}(A::FixedArray{T,N,SZ})                = length(A)
 

--- a/src/core.jl
+++ b/src/core.jl
@@ -2,9 +2,9 @@ abstract FixedArray{T, NDim, SIZE}
 abstract MutableFixedArray{T, NDim, SIZE} <: FixedArray{T, NDim, SIZE}
 
 typealias MutableFixedVector{T, CARDINALITY} MutableFixedArray{T, 1, Tuple{CARDINALITY}}
-typealias MutableFixedMatrix{T, M, N} 		 MutableFixedArray{T, 2, Tuple{M,N}}
+typealias MutableFixedMatrix{T, M, N}        MutableFixedArray{T, 2, Tuple{M,N}}
 
-typealias FixedVector{CARDINALITY, T} FixedArray{T, 1, Tuple{CARDINALITY,}}
+typealias FixedVector{CARDINALITY, T}        FixedArray{T, 1, Tuple{CARDINALITY,}}
 typealias FixedMatrix{Row, Column, T}        FixedArray{T, 2, Tuple{Row, Column}}
 
 abstract FixedVectorNoTuple{CARDINALITY, T} <: FixedVector{CARDINALITY, T}
@@ -27,14 +27,14 @@ eltype{T <: FixedArray}(A::T)                       = eltype(T)
 
 length{T,N,SZ}(A::Type{FixedArray{T,N,SZ}})         = prod(SZ.parameters)::Int
 length{T <: FixedArray}(A::Type{T})                 = length(fixedsizearray_type(T))
-length{T <: FixedArray}(A::T)           	        = length(T)
+length{T <: FixedArray}(A::T)                       = length(T)
 
 
 endof{T,N,SZ}(A::FixedArray{T,N,SZ})                = length(A)
 
 
 ndims{T,N,SZ}(A::Type{FixedArray{T,N,SZ}})          = N
-ndims{T <: FixedArray}(A::Type{T})            		= ndims(fixedsizearray_type(T))
+ndims{T <: FixedArray}(A::Type{T})                  = ndims(fixedsizearray_type(T))
 ndims{T <: FixedArray}(A::T)                        = ndims(T)
 
 size{T,N,SZ}(A::Type{FixedArray{T,N,SZ}})           = (SZ.parameters...)::NTuple{N, Int}
@@ -42,12 +42,12 @@ size{T <: FixedArray}(A::Type{T})                   = size(fixedsizearray_type(T
 size{T <: FixedArray}(A::T)                         = size(T)
 
 size{T <: FixedArray}(A::T, d::Integer)             = size(T, d)
-size{T <: FixedArray}(A::Type{T}, d::Integer) 		= size(T)[d]::Int
+size{T <: FixedArray}(A::Type{T}, d::Integer)       = size(T)[d]::Int
 
 # Iterator
-start(A::FixedArray)            					= 1
-next(A::FixedArray, state::Integer) 				= (A[state], state+1)
-done(A::FixedArray, state::Integer) 				= length(A) < state
+start(A::FixedArray)                                = 1
+next(A::FixedArray, state::Integer)                 = (A[state], state+1)
+done(A::FixedArray, state::Integer)                 = length(A) < state
 
 
 


### PR DESCRIPTION
Before:

```
julia> v = Vec(1,2)
FixedSizeArrays.Vec{2,Int64}((1,2))

julia> @code_llvm length(v)

define i64 @julia_length_21519(%Vec*) {
top:
  %1 = alloca [3 x %jl_value_t*], align 8
  %.sub = getelementptr inbounds [3 x %jl_value_t*]* %1, i64 0, i64 0
  %2 = getelementptr [3 x %jl_value_t*]* %1, i64 0, i64 2
  store %jl_value_t* inttoptr (i64 2 to %jl_value_t*), %jl_value_t** %.sub, align 8
  %3 = getelementptr [3 x %jl_value_t*]* %1, i64 0, i64 1
  %4 = load %jl_value_t*** @jl_pgcstack, align 8
  %.c = bitcast %jl_value_t** %4 to %jl_value_t*
  store %jl_value_t* %.c, %jl_value_t** %3, align 8
  store %jl_value_t** %.sub, %jl_value_t*** @jl_pgcstack, align 8
  store %jl_value_t* inttoptr (i64 139957089856592 to %jl_value_t*), %jl_value_t** %2, align 8
  %5 = call %jl_value_t* @julia_fixedsizearray_type_21520(%jl_value_t* inttoptr (i64 139957059843184 to %jl_value_t*), %jl_value_t** %2, i32 1)
  store %jl_value_t* %5, %jl_value_t** %2, align 8
  %6 = call %jl_value_t* @jl_apply_generic(%jl_value_t* inttoptr (i64 139957051721296 to %jl_value_t*), %jl_value_t** %2, i32 1)
  %7 = bitcast %jl_value_t* %6 to i64*
  %8 = load i64* %7, align 16
  %9 = load %jl_value_t** %3, align 8
  %10 = getelementptr inbounds %jl_value_t* %9, i64 0, i32 0
  store %jl_value_t** %10, %jl_value_t*** @jl_pgcstack, align 8
  ret i64 %8
}
```

After:

```
julia> v = Vec(1,2)
FixedSizeArrays.Vec{2,Int64}((1,2))

julia> @code_llvm length(v)

define i64 @julia_length_21515(%Vec*) {
top:
  ret i64 2
}
```

Also some spaces-> tabs fixes
