### PR TITLE
When possible, execute fill_tuple_expr at compile-time, not run-time

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -69,7 +69,12 @@ call(pf::ParseFunctor{Void}, i::Int) = parse(pf.a[i])
     end
     SZ     = size_or(FSA, :(size(a)))
     ElType = eltype_or(FSA, eltype(a))
-    expr = :($FSA(fill_tuples((sz, i...)->$ElType(a[i...]), $SZ)))
+    if isa(SZ, Expr)
+        expr = :($FSA(fill_tuples((sz, i...)->$ElType(a[i...]), $SZ)))
+    else
+        tupexpr = fill_tuples_expr((i,inds...) -> :($ElType(a[$i, $(inds...)])), SZ)
+        expr = :($FSA($tupexpr))
+    end
     if FSA <: FixedVectorNoTuple
         expr = :($FSA(a...))
     end


### PR DESCRIPTION
If we know the size of the destination at compile time, we can generate expressions `tuple(tuple(Float64(a[1,1]), Float64(a[2,1]), ...), ...)` then. This avoids the need to run an anonymous function at runtime. In an application I'm working on, this change resulted in a 30x speed improvement in the entire algorithm.
