### PR TITLE
RFC: Unified slicing across fixed and variable dimensions

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -63,4 +63,6 @@ export column
 export MatMulFunctor
 export setindex
 export eltype_or, size_or
+export FSlice
+export destructure
 end

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -23,6 +23,7 @@ immutable Point{N, T} <: FixedVector{N, T}
 end
 
 include("mapreduce.jl")
+include("destructure.jl")
 include("indexing.jl")
 include("ops.jl")
 include("expm.jl")

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -63,6 +63,6 @@ export column
 export MatMulFunctor
 export setindex
 export eltype_or, size_or
-export FSlice
+export @fslice
 export destructure
 end

--- a/src/destructure.jl
+++ b/src/destructure.jl
@@ -1,0 +1,50 @@
+"Destructuring view around an arbitrary abstract array.  See destructure()"
+immutable DestructuredArray{T,N,ArrayT} <: AbstractArray{T,N}
+    base::ArrayT
+end
+
+import Base.linearindexing
+
+linearindexing(::Type{DestructuredArray}) = Base.LinearSlow()
+size{T,N,ArrayT}(a::DestructuredArray{T,N,ArrayT}) = (size(eltype(ArrayT))..., size(a.base)...)
+
+@generated function getindex{T,N,ArrayT}(a::DestructuredArray{T,N,ArrayT}, inds::Int...)
+    eldims = ndims(eltype(ArrayT))
+    # We'd like to just do
+    # a.base[inds[eldims+1:end]...][inds[1:eldims]...]
+    # but splatting is currently (2015-12) a performance disaster
+    fixinds = [:(inds[$i]) for i in 1:eldims]
+    baseinds = [:(inds[$i]) for i in eldims+1:length(inds)]
+    quote
+        a.base[$(baseinds...)][$(fixinds...)]
+    end
+end
+
+@generated function setindex!{T,N,ArrayT}(a::DestructuredArray{T,N,ArrayT}, value, inds::Int...)
+    eldims = ndims(eltype(ArrayT))
+    fixinds = [:(inds[$i]) for i in 1:eldims]
+    baseinds = [:(inds[$i]) for i in eldims+1:length(inds)]
+    quote
+        # TODO: FixedSizeArrays.setindex gives a rather severe performance
+        # penalty here.
+        a.base[$(baseinds...)] = setindex(a.base[$(baseinds...)], value, $(fixinds...))
+    end
+end
+
+
+"""
+Destructure the elements of an array `a` to create `M=ndims(eltype(a))`
+additional dimensions prefixing the dimensions of `a`.  The returned array is a
+view onto the original elements, with fixed dimensions first according to the
+natural memory ordering.
+
+For example, `AbstractArray{F<:FixedArray{T,M,SIZE},N}` appears as as an
+`AbstractArray{T,M+N}`.
+"""
+function destructure{ArrayT<:AbstractArray}(a::ArrayT)
+    DestructuredArray{eltype(eltype(a)), ndims(a)+ndims(eltype(a)), ArrayT}(a)
+end
+
+# Faster (as of 2015-12) reinterpret-based version for plain Array
+destructure{T,N}(a::Array{T,N}) = reinterpret(eltype(T), a, (size(T)..., size(a)...))
+

--- a/src/destructure.jl
+++ b/src/destructure.jl
@@ -6,37 +6,37 @@ immutable DestructuredArray{T,N,ArrayT} <: AbstractArray{T,N}
     base::ArrayT
 end
 
-function DestructuredArray{ArrayT<:AbstractArray}(a::ArrayT)
-    DestructuredArray{eltype(eltype(a)), ndims(a)+ndims(eltype(a)), ArrayT}(a)
+function DestructuredArray{ArrayT<:AbstractArray}(A::ArrayT)
+    DestructuredArray{eltype(eltype(A)), ndims(A)+ndims(eltype(A)), ArrayT}(A)
 end
 
 linearindexing(::Type{DestructuredArray}) = Base.LinearSlow()
-size{T,N,ArrayT}(a::DestructuredArray{T,N,ArrayT}) = (size(eltype(ArrayT))..., size(a.base)...)
+size{T,N,ArrayT}(A::DestructuredArray{T,N,ArrayT}) = (size(eltype(ArrayT))..., size(A.base)...)
 
 # TODO: Should define similar() but it doesn't work for sparse matrices in 0.4
 # since they don't support more than two dimensions.
-# similar{S,D}(a::DestructuredArray, ::Type{S}, dims::NTuple{D,Int}) = similar(a.base, S, dims...)
+# similar{S,D}(A::DestructuredArray, ::Type{S}, dims::NTuple{D,Int}) = similar(A.base, S, dims...)
 
-@generated function getindex{T,N,ArrayT}(a::DestructuredArray{T,N,ArrayT}, inds::Int...)
+@generated function getindex{T,N,ArrayT}(A::DestructuredArray{T,N,ArrayT}, inds::Int...)
     eldims = ndims(eltype(ArrayT))
     # We'd like to just do
-    # a.base[inds[eldims+1:end]...][inds[1:eldims]...]
+    # A.base[inds[eldims+1:end]...][inds[1:eldims]...]
     # but splatting is currently (2015-12) a performance disaster
     fixinds = [:(inds[$i]) for i in 1:eldims]
     baseinds = [:(inds[$i]) for i in eldims+1:length(inds)]
     quote
-        a.base[$(baseinds...)][$(fixinds...)]
+        A.base[$(baseinds...)][$(fixinds...)]
     end
 end
 
-@generated function setindex!{T,N,ArrayT}(a::DestructuredArray{T,N,ArrayT}, value, inds::Int...)
+@generated function setindex!{T,N,ArrayT}(A::DestructuredArray{T,N,ArrayT}, value, inds::Int...)
     eldims = ndims(eltype(ArrayT))
     fixinds = [:(inds[$i]) for i in 1:eldims]
     baseinds = [:(inds[$i]) for i in eldims+1:length(inds)]
     quote
         # TODO: FixedSizeArrays.setindex gives a rather severe performance
         # penalty here.
-        a.base[$(baseinds...)] = setindex(a.base[$(baseinds...)], value, $(fixinds...))
+        A.base[$(baseinds...)] = setindex(A.base[$(baseinds...)], value, $(fixinds...))
     end
 end
 
@@ -53,5 +53,5 @@ For example, `AbstractArray{F<:FixedArray{T,M,SIZE},N}` appears as an
 destructure(A::AbstractArray) = DestructuredArray(A)
 
 # Faster reinterpret-based version (as of 2015-12) for plain Array
-destructure{T,N}(A::Array{T,N}) = reinterpret(eltype(T), A, (size(T)..., size(a)...))
+destructure{T,N}(A::Array{T,N}) = reinterpret(eltype(T), A, (size(T)..., size(A)...))
 

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -41,7 +41,6 @@
     end
 end
 
-
 # Turn `A[1,2,...]` into `destructure(A)[1,2,3,4]`
 #
 # Turn `A[:x,:y,1,2,...]` into

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -26,3 +26,35 @@
 @inline crow{R, T}(a::Mat{R, 3, T}, j::Int) = (a.(1)[1][j]', a.(1)[2][j]', a.(1)[3][j]')
 @inline crow{R, T}(a::Mat{R, 4, T}, j::Int) = (a.(1)[1][j]', a.(1)[2][j]', a.(1)[3][j]', a.(1)[4][j]',)
 
+
+# Placeholder type for dispatch to slice along fixed dimensions of
+# Array{F<:FixedArray}
+immutable FSlice; end
+
+"""
+Remove the fixed dimensional structure from an
+`Array{F<:FixedArray{T,M,SIZE},N}`, reinterpreting it as an `Array{T,M+N}`, in
+natural memory ordering (ie, fixed dimensions first).
+"""
+function destructure{F<:FixedArray}(a::Array{F})
+    SIZE = size(F)
+    T = eltype(F)
+    reinterpret(T, a, (SIZE..., size(a)...))
+end
+
+function getindex{F<:FixedArray}(a::Array{F}, ::Type{FSlice}, inds...)
+    destructure(a)[inds...]
+end
+
+function setindex!{F<:FixedArray}(a::Array{F}, val, ::Type{FSlice}, inds...)
+    destructure(a)[inds...] = val
+end
+
+function getindex{F<:FixedVectorNoTuple}(a::Array{F}, fieldname::Symbol, inds...)
+    # Not terribly efficient; can we somehow force the field index to be
+    # resolved at compile time?
+    fieldindex = findfirst(fieldnames(F), fieldname)
+    fieldindex > 0 || error("No field named $fieldname in $(typeof(a))")
+    destructure(a)[fieldindex, inds...]
+end
+

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -58,6 +58,11 @@ function getindex{F<:FixedVectorNoTuple}(a::Array{F}, fieldname::Symbol, inds...
     destructure(a)[fieldindex, inds...]
 end
 
+function setindex!{F<:FixedVectorNoTuple}(a::Array{F}, val, fieldname::Symbol, inds...)
+    fieldindex = findfirst(fieldnames(F), fieldname)
+    fieldindex > 0 || error("No field named $fieldname in $(typeof(a))")
+    destructure(a)[fieldindex, inds...] = val
+end
 
 # Turn A[1,2,...] into A[FSlice, 1,2,3,4]
 function fixed_slice_expr(expr)

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -29,14 +29,18 @@
 
 # Unified slicing along combinations of fixed and variable dimensions
 
-"Get index of a field with `name` in type `T`.  Should this be in base?"
-function fieldindex{T}(::Type{T}, name::Symbol)
-    i = findfirst(fieldnames(T), name)
-    if i == 0
+"Get index of a field with `name` in type `T`.  Should this be in Base?"
+@generated function fieldindex{T}(::Type{T}, name::Symbol)
+    # Expand all field names inline to allow this to become a constant
+    # expression.  Simple alternative is `findfirst(fieldnames(T), name)`
+    exprs = [:($(Expr(:quote, n)) == name && return $i) for (i,n) in enumerate(fieldnames(T))]
+    quote
+        $(Expr(:meta, :inline))
+        $(exprs...)
         error("No field \"$name\" in type $T")
     end
-    i
 end
+
 
 # Turn `A[1,2,...]` into `destructure(A)[1,2,3,4]`
 #

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -50,7 +50,7 @@ function setindex!{F<:FixedArray}(a::Array{F}, val, ::Type{FSlice}, inds...)
     destructure(a)[inds...] = val
 end
 
-function getindex{F<:FixedVectorNoTuple}(a::Array{F}, fieldname::Symbol, inds...)
+function getindex{F<:FixedVectorNoTuple}(a::Array{F}, ::Type{FSlice}, fieldname::Symbol, inds...)
     # Not terribly efficient; can we somehow force the field index to be
     # resolved at compile time?
     fieldindex = findfirst(fieldnames(F), fieldname)
@@ -58,7 +58,7 @@ function getindex{F<:FixedVectorNoTuple}(a::Array{F}, fieldname::Symbol, inds...
     destructure(a)[fieldindex, inds...]
 end
 
-function setindex!{F<:FixedVectorNoTuple}(a::Array{F}, val, fieldname::Symbol, inds...)
+function setindex!{F<:FixedVectorNoTuple}(a::Array{F}, val, ::Type{FSlice}, fieldname::Symbol, inds...)
     fieldindex = findfirst(fieldnames(F), fieldname)
     fieldindex > 0 || error("No field named $fieldname in $(typeof(a))")
     destructure(a)[fieldindex, inds...] = val
@@ -91,6 +91,14 @@ Examples:
     # Vector of fixed size matrices
     m = [@fsa([i 0; 0 i^2]) for i=1:4]
     @fslice m[1,1,:]
+
+    # Slice immutables by field name
+    immutable MyVec <: FixedVectorNoTuple{2,Float64}
+        x::Float64
+        y::Float64
+    end
+    v = MyVec[MyVec(i,-i) for i=1:5]
+    @fslice v[:x, :]
 """
 macro fslice(expr)
     esc(fixed_slice_expr(expr))

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -27,52 +27,52 @@
 @inline crow{R, T}(a::Mat{R, 4, T}, j::Int) = (a.(1)[1][j]', a.(1)[2][j]', a.(1)[3][j]', a.(1)[4][j]',)
 
 
-# Placeholder type for dispatch to slice along fixed dimensions of
-# Array{F<:FixedArray}
-immutable FSlice; end
+# Unified slicing along combinations of fixed and variable dimensions
 
-"""
-Remove the fixed dimensional structure from an
-`Array{F<:FixedArray{T,M,SIZE},N}`, reinterpreting it as an `Array{T,M+N}` in
-natural memory ordering (ie, fixed dimensions first).
-"""
-function destructure{F<:FixedArray}(a::Array{F})
-    SIZE = size(F)
-    T = eltype(F)
-    reinterpret(T, a, (SIZE..., size(a)...))
+"Get index of a field with `name` in type `T`.  Should this be in base?"
+function fieldindex{T}(::Type{T}, name::Symbol)
+    i = findfirst(fieldnames(T), name)
+    if i == 0
+        error("No field \"$name\" in type $T")
+    end
+    i
 end
 
-function getindex{F<:FixedArray}(a::Array{F}, ::Type{FSlice}, inds...)
-    destructure(a)[inds...]
-end
-
-function setindex!{F<:FixedArray}(a::Array{F}, val, ::Type{FSlice}, inds...)
-    destructure(a)[inds...] = val
-end
-
-function getindex{F<:FixedVectorNoTuple}(a::Array{F}, ::Type{FSlice}, fieldname::Symbol, inds...)
-    # Not terribly efficient; can we somehow force the field index to be
-    # resolved at compile time?
-    fieldindex = findfirst(fieldnames(F), fieldname)
-    fieldindex > 0 || error("No field named $fieldname in $(typeof(a))")
-    destructure(a)[fieldindex, inds...]
-end
-
-function setindex!{F<:FixedVectorNoTuple}(a::Array{F}, val, ::Type{FSlice}, fieldname::Symbol, inds...)
-    fieldindex = findfirst(fieldnames(F), fieldname)
-    fieldindex > 0 || error("No field named $fieldname in $(typeof(a))")
-    destructure(a)[fieldindex, inds...] = val
-end
-
-# Turn A[1,2,...] into A[FSlice, 1,2,3,4]
+# Turn `A[1,2,...]` into `destructure(A)[1,2,3,4]`
+#
+# Turn `A[:x,:y,1,2,...]` into
+# `destructure(A)[fieldindex(eltype(A),:x), fieldindex(eltype(A),:y), 1,2,...]`
+#
+# Also works on the left side of an assignment
 function fixed_slice_expr(expr)
+    assignrhs = nothing
     if expr.head == :(=)
-        return Expr(expr.head, fixed_slice_expr(expr.args[1]), expr.args[2:end]...)
+        @assert length(expr.args) == 2
+        assignrhs = expr.args[2]
+        expr = expr.args[1]
     end
     expr.head == :ref || error("Array reference not found in expression $expr")
+    inds = Any[]
     name = expr.args[1]
-    inds = expr.args[2:end]
-    Expr(:ref, expr.args[1], FSlice, expr.args[2:end]...)
+    for i = 2:length(expr.args)
+        ind = expr.args[i]
+        if isa(ind,Expr) && ind.head == :quote
+            push!(inds, :(fieldindex(eltype(tmp), $(esc(ind)))))
+        else
+            push!(inds, esc(ind))
+        end
+    end
+    if assignrhs === nothing
+        quote
+            tmp = $(esc(name))
+            destructure(tmp)[$(inds...)]
+        end
+    else
+        quote
+            tmp = $(esc(name))
+            destructure(tmp)[$(inds...)] = $(esc(assignrhs))
+        end
+    end
 end
 
 """
@@ -101,5 +101,5 @@ Examples:
     @fslice v[:x, :]
 """
 macro fslice(expr)
-    esc(fixed_slice_expr(expr))
+    fixed_slice_expr(expr)
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -308,6 +308,18 @@ context("Complex Ops") do
     end
 end
 
+context("Destructure") do
+    rgb = [RGB(i,2*i,3*i) for i=1:4]
+    rgb_ref = [1 2 3 4;
+               2 4 6 8;
+               3 6 9 12]
+    @fact destructure(rgb) --> rgb_ref
+    @fact FixedSizeArrays.DestructuredArray(rgb) --> rgb_ref
+
+    A = [@fsa([i 2*i; 3*i 4*i]) for i=1:2]
+    @fact destructure(A) --> cat(3, [1 2; 3 4], [2 4; 6 8])
+end
+
 context("Indexing") do
 	context("FixedVector") do
         @fact setindex(v1, 88.9, 1) --> Vec(88.9,2.0,3.0)
@@ -355,6 +367,39 @@ context("Indexing") do
 
     end
 
+    context("fslice") do
+        rgb = [RGB(i,2*i,3*i) for i=1:10]
+
+        # Plain indexing
+        @fact @fslice(rgb[1,2]) --> rgb[2].r
+        @fact @fslice(rgb[2,5]) --> rgb[5].g
+        @fact @fslice(rgb[3,8]) --> rgb[8].b
+
+        # Slicing along fixed dims
+        @fact @fslice(rgb[:,1]) --> rgb[1]
+        @fact @fslice(rgb[:,end]) --> rgb[end]
+
+        # Slicing across fixed dims
+        @fact @fslice(rgb[1,:])  --> [c.r for c in rgb]
+        @fact @fslice(rgb[2,:])  --> [c.g for c in rgb]
+        @fact @fslice(rgb[3,:])  --> [c.b for c in rgb]
+        # Slicing across fixed dims with field names
+        @fact @fslice(rgb[:r,:]) --> [c.r for c in rgb]
+        @fact @fslice(rgb[:g,:]) --> [c.g for c in rgb]
+        @fact @fslice(rgb[:b,:]) --> [c.b for c in rgb]
+
+        # Slicing FSAs with two fixed dimensions
+        N = 3
+        A = [@fsa([i 2*i; 3*j 4*j]) for i=1:N, j=1:N]
+        for i=1:N,j=1:N
+            @fact @fslice(A[:,:,i,j]) --> A[i,j]
+        end
+        @fact @fslice(A[1,1,:,1]) --> [A[i,1][1,1] for i=1:N]
+        @fact @fslice(A[end,end,end,:]) --> [A[end,j][end,end] for j=1:N]
+        @fact @fslice(A[1,[1,end],1,1]) --> [A[1,1][1,1], A[1,1][1,end]]
+
+        # TODO: test setindex
+    end
 end
 
 


### PR DESCRIPTION
~~WIP, do not merge!~~ This is ready for a look now.

As discussed in #59, here's what I've got so far for slicing across both fixed and variable dimensions in a combined expression.

I ended up settling on a macro `@fslice` because I couldn't yet figure out how to implement something like `A[1,2,3]` - where `1` indexes a fixed dimension, and `2,3` index variable dimensions - in a way that's simple and doesn't clash with the default base implementation of `getindex()`.  In particular, you'd still like `A[2,3]` to work properly down and return the immutable at index 2.  ~~(Actually, having written the above, I think it may be fairly straightforward using `@generated` functions, I'll give that a go next~~ this is tricky, because if you override the default `getindex`, you suddenly can't call through to the default implementation anymore, which is what you need to implement the overridden `getindex` itself!)

While it's a bit ugly, I think `@fslice` at least gives you a hint that something slightly odd is going on.

Example usage:

``` julia
# Array of fixed size vectors
a = [Vec(i,j) for i=1:5, j=1:5]
@fslice a[2,:,:] = 10
xcomps = @fslice a[1,:,:]

# Vector of fixed size matrices
m = [@fsa([i 0; 0 i^2]) for i=1:4]
@fslice m[1,1,:]

# Slice immutables by field name
immutable MyVec <: FixedVectorNoTuple{2,Float64}
    x::Float64
    y::Float64
end
v = MyVec[MyVec(i,-i) for i=1:5]
@fslice v[:x, :]
```
