### PR TITLE
fix #56 and #65

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,6 @@ notifications:
   email: false
 script:
     - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-    - julia -e 'Pkg.clone(pwd()); Pkg.test("FixedSizeArrays"; coverage=true)'
+    - julia --inline=no -e 'Pkg.clone(pwd()); Pkg.test("FixedSizeArrays"; coverage=true)'
 after_success:
   - julia -e 'cd(Pkg.dir("FixedSizeArrays")); Pkg.add("Coverage"); using Coverage; Coveralls.submit(process_folder()); Codecov.submit(process_folder())'

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -17,6 +17,9 @@ end
 immutable Mat{Row, Column, T} <: FixedMatrix{Row, Column, T}
     _::NTuple{Column, NTuple{Row, T}}
 end
+function similar{FSA <: Mat, T}(::Type{FSA}, ::Type{T}, SZ::NTuple{2, Int})
+    Mat{SZ[1], SZ[2], T}
+end
 
 # most common FSA types
 immutable Vec{N, T} <: FixedVector{N, T}


### PR DESCRIPTION
This should fix the most daring issues. (`Vec{2}(0.0)` should work now, even though constructor code is still messy... )
Also, `FixedVectorNoTuple` must only have a tuple constructor now.
This is necessary, because otherwise I need to define a constructor for every `N` of `FixedVectorNoTuple` (The default constructor is ambiguous with the multiple arg constructors from `FixedSizeArrays`).
So it should look like this now:

``` Julia
immutable RGB{T} <: FixedVectorNoTuple{3, T}
    r::T
    g::T
    b::T
    function RGB(a::NTuple{3, T})
        new{T}(a[1], a[2], a[3])
    end
end
```
