### PR TITLE
Add comparison functions

### DIFF
--- a/src/ops.jl
+++ b/src/ops.jl
@@ -78,9 +78,11 @@ for (op_all, op_el) in comparisonOps
     functor_name_el, functor_expr_el = gen_functor(op_el, 2)
     eval(quote
         $functor_expr_el
-        @inline $op_el{T <: FixedArray}(x::T, y::T) = map($functor_name_el(), x, y)
+        # TODO: Current hack is to `map(Bool, operation)` Should be removed when
+        #       map functionality is updated.
+        @inline $op_el{T <: FixedArray}(x::T, y::T) = map(Bool, map($functor_name_el(), x, y))
         @inline $op_el{T1 <: FixedArray, T2 <: FixedArray}(x::T1, y::T2) = $op_el(promote(x, y)...)
-
+        @inline $op_all{T <: FixedArray}(x::T, y::T) = all($op_el(x, y))
         @inline $op_all{T1 <: FixedArray, T2 <: FixedArray}(x::T1, y::T2) = all($op_el(x, y))
     end)
 

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -19,12 +19,15 @@ const unaryOps = (:-, :~, :conj, :abs,
                   :eta, :zeta, :digamma)
 
 # vec-vec and vec-scalar
-const binaryOps = (:.+, :.-,:.*, :./, :.\, :.^,
-                   :.==, :.!=, :.<, :.<=, :.>, :.>=, :+, :-,
+const binaryOps = (:.+, :.-,:.*, :./, :.\, :.^, :+, :-,
                    :min, :max,
                    :div, :fld, :rem, :mod, :mod1, :cmp,
                    :atan2, :besselj, :bessely, :hankelh1, :hankelh2,
                    :besseli, :besselk, :beta, :lbeta)
+
+# Pair by comparison of all elements and element wise comparisons
+const comparisonOps = ((:(==), :(.==)), (:(!=), :(.!=)), (:(<), :(.<)), (:(<=),
+                        :(.<=)), (:(>), :(.>)), (:(>=), :(.>=)))
 
 const matrixOps = (:*, :/)
 
@@ -67,6 +70,20 @@ for op in binaryOps
         @inline $op{T <: Number}(x::FixedArray{T}, y::T) = map($functor_name(), x, y)
         @inline $op{T1, T2 <: Number}(x::FixedArray{T1}, y::T2) = $op(promote(x, y)...)
     end)
+end
+
+for (op_all, op_el) in comparisonOps
+
+    # Define element wise operations
+    functor_name_el, functor_expr_el = gen_functor(op_el, 2)
+    eval(quote
+        $functor_expr_el
+        @inline $op_el{T <: FixedArray}(x::T, y::T) = map($functor_name_el(), x, y)
+        @inline $op_el{T1 <: FixedArray, T2 <: FixedArray}(x::T1, y::T2) = $op_el(promote(x, y)...)
+
+        @inline $op_all{T1 <: FixedArray, T2 <: FixedArray}(x::T1, y::T2) = all($op_el(x, y))
+    end)
+
 end
 
 for op in matrixOps

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -952,14 +952,14 @@ const unaryOps = (
 # vec-vec and vec-scalar
 const binaryOps = (
     .+, .-,.*, ./, .\, /,
-    .==, .!=, .<, .<=, .>, .>=, +, -,
     min, max,
 
     atan2, besselj, bessely, hankelh1, hankelh2,
     besseli, besselk, beta, lbeta
 )
 
-
+const comparisonOps = ((:(==), :(.==)), (:(!=), :(.!=)), (:(<), :(.<)), (:(<=),
+                        :(.<=)), (:(>), :(.>)), (:(>=), :(.>=)))
 
 
 context("mapping operators") do
@@ -1000,6 +1000,18 @@ context("mapping operators") do
                 end
             end
         end
+    end
+    context("comparison: ") do
+
+        @fact Vec(1, 2, 3).<Vec(2, 1, 4) --> Vec(true, false, true)
+        @fact Vec(1, 2, 3)<Vec(2, 1, 4) --> false
+
+        @fact Mat((1.0, 2.0), (3.0, 4.0)).>Mat((2.0, 3.0), (4.0, 5.0)) --> Mat((false, false), (false, false))
+        @fact Mat((1.0, 2.0), (3.0, 4.0))>Mat((2.0, 3.0), (4.0, 5.0)) --> false
+
+        @fact Vec(1, 2, 3).==Vec(1, 2, 3) --> Vec(true, true, true)
+        @fact Vec(1, 2, 3)==Vec(1, 2, 3) --> true
+
     end
 end
 


### PR DESCRIPTION
This pull request adds a new group of binary operators for comparisons by implementing `(==, <, <=, >, >=)` instead of just their element-wise counterparts.

This isn't quite ready to merge. One lingering implementation issue corresponds to the points raised in #63 with the type stability enforced by the `FixedSizeArrays` version of `map`. The new operators rely on being able to call `all(x .? y)` which won't work unless the output of `x .? y` is a boolean.

Don't know if this will be helpful, but I thought I'd throw this out for review.
