### PR TITLE
RandnFunctor

### DIFF
--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -144,6 +144,10 @@ zero(fsa::FixedArray) = zero(typeof(fsa))
     T = eltype(FSA)
     map(RandFunctor(T(first(range)):T(step(range)):T(last(range))), FSA) # there's no easy way to convert eltypes of ranges (I think)
 end
+@inline randn{FSA <: FixedArray}(m::MersenneTwister, x::Type{FSA}) = map(RandnFunctor{eltype(FSA)}(m), FSA)
+@inline randn{FSA <: FixedArray}(x::Type{FSA}) = map(RandnFunctor{eltype(FSA)}(Base.Random.GLOBAL_RNG), FSA)
+
+
 """
 Macro `fsa` helps to create fixed size arrays like Julia arrays.
 E.g.

--- a/src/functors.jl
+++ b/src/functors.jl
@@ -2,10 +2,17 @@ immutable MersenneFunctor{T} <: Func{1}
     mt::MersenneTwister
 end
 @inline call{T}(rf::MersenneFunctor{T}, i...) = rand(rf.mt, T)
+
 immutable RandFunctor{T} <: Func{1}
     valuerange::T
 end
 @inline call(rf::RandFunctor, i...) = rand(rf.valuerange)
+immutable RandnFunctor{T} <: Func{1}
+    mt::MersenneTwister
+end
+@inline call(rf::RandnFunctor{Float64}, i...) = randn(rf.mt)
+@inline call(rf::RandnFunctor{Complex{Float64}}, i...) = randn(rf.mt) + im*randn(rf.mt)
+
 immutable ConstFunctor{T} <: Base.Func{1}
     args::T
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -220,6 +220,13 @@ context("Constructor ") do
         @fact size(x) --> (4,4,4)
         @fact typeof(rand(Vec4d, 5,5)) --> Matrix{Vec4d}
     end
+    context("Randn") do
+        @fact typeof(randn(Base.Random.GLOBAL_RNG, Vec4d)) --> Vec4d
+        @fact typeof(randn(Vec4d)) --> Vec4d
+        @fact typeof(randn(Mat4d)) --> Mat4d
+        @fact typeof(randn(Mat{4,2, Complex{Float64}})) --> Mat{4,2, Complex{Float64}}
+        @fact typeof(randn(Vec{7, Complex{Float64}})) --> Vec{7, Complex{Float64}}
+    end
     context("Zero") do
         @fact typeof(zero(Vec4d)) --> Vec4d
         @fact typeof(zero(Mat4d)) --> Mat4d


### PR DESCRIPTION
RandnFunctor, as discussed in #75. There is a small asymmetry in base that  `rand` has signature 

```
rand([rng], [S], [dims...])
```

but `randn` has signature

```
randn([rng], [dims...])
```

For us it is nevertheless sensible to define `randn([rng], ::Type{FSA})` for `Float64` and `Complex{Float64}` f.s.-arrays. 
