### PR TITLE
Changed isapprox to be consistent with Base

### DIFF
--- a/src/array_of_fixedsize.jl
+++ b/src/array_of_fixedsize.jl
@@ -12,11 +12,15 @@ call(::MaxFun, a, b) = max(a, b)
 call(::MinFun, a, b) = min(a, b)
 minimum{T <: FixedArray}(a::Vector{T}) = reduce(MinFun(), a)
 maximum{T <: FixedArray}(a::Vector{T}) = reduce(MaxFun(), a)
-function isapprox{FSA <: FixedArray, A <: Union{Array, FixedArray}}(a::FSA, b::A)
-    for i=1:length(a)
-        !isapprox(a[i], b[i]) && return false
-    end
-    true
+
+function isapprox{FSA <: FixedArray, A <: FixedArray}(x::FSA, y::A; rtol::Real=Base.rtoldefault(eltype(x),eltype(y)), atol::Real=0, norm::Function=vecnorm)
+    # Same behaviour as AbstractArray: julia/base/linalg/generic.jl
+	d = norm(x - y)
+    return isfinite(d) ? d <= atol + rtol*max(norm(x), norm(y)) : x == y
+end
+function isapprox{FSA <: FixedArray, A <: Array}(x::FSA, y::A; rtol::Real=Base.rtoldefault(eltype(x),eltype(y)), atol::Real=0, norm::Function=vecnorm)
+    d = norm(Array(x) - y) # operations between Arrays and FixedArrays not defined...
+    return isfinite(d) ? d <= atol + rtol*max(norm(x), norm(y)) : x == y
 end
 
 (.+){T<:FixedArray, ND}(a::Array{T, ND}, x::T) = T[elem .+ x for elem in a]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -957,6 +957,7 @@ context("Equality") do
     @fact Vec(1,2,3) --> [1,2,3]
     @fact Mat((1,2),(3,4)) --> Mat((1,2),(3,4))
     @fact one(Mat{4,1, Float32}) --> one(Vec{4, Float32})
+    @fact isapprox(Vec(1.0,0.0), Vec(1.0,1e-14)) --> true
 end
 #=
 #don't have this yet


### PR DESCRIPTION
Before, `isapprox` failed to take into account of the norm of the overall
matrix/vector/array. For example, `isapprox(Vec(1.0, 0.0), Vec(1.0, 1e-14))` failed.
Now we are consistent with the behaviour of `Array` in `Base`.
