### PR TITLE
Fix getfield depwarn

### DIFF
--- a/src/core.jl
+++ b/src/core.jl
@@ -100,5 +100,5 @@ end
     :(tuple($(ntuple(i->:(f[$i]), N)...)))
 end
 function get_tuple(f::FixedArray)
-    f.(1) # a little wonky, but there really no much sense if isn't the only field
+    f._
 end

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -1,5 +1,5 @@
 @inline getindex{T <: FixedVector}(x::T, i::Union{Range, Integer}) = x._[i]
-@inline getindex{T <: FixedVectorNoTuple}(x::T, i::Integer) = x.(i)
+@inline getindex{T <: FixedVectorNoTuple}(x::T, i::Integer) = getfield(x,i)
 @inline getindex{N, M, T}(a::Mat{N, M, T}, i::Range, j::Int) = ntuple(IndexFunc(a, j), Val{length(i)})::NTuple{length(i), T}
 @inline getindex{N, M, T}(a::Mat{N, M, T}, i::Int, j::Union{Range, Int}) = a._[j][i]
 @inline getindex{N, M, T}(a::Mat{N, M, T}, i::Int) = a[ind2sub((N,M), i)...]

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -1,30 +1,30 @@
-@inline getindex{T <: FixedVector}(x::T, i::Union{Range, Integer}) = x.(1)[i]
+@inline getindex{T <: FixedVector}(x::T, i::Union{Range, Integer}) = x._[i]
 @inline getindex{T <: FixedVectorNoTuple}(x::T, i::Integer) = x.(i)
 @inline getindex{N, M, T}(a::Mat{N, M, T}, i::Range, j::Int) = ntuple(IndexFunc(a, j), Val{length(i)})::NTuple{length(i), T}
-@inline getindex{N, M, T}(a::Mat{N, M, T}, i::Int, j::Union{Range, Int}) = a.(1)[j][i]
+@inline getindex{N, M, T}(a::Mat{N, M, T}, i::Int, j::Union{Range, Int}) = a._[j][i]
 @inline getindex{N, M, T}(a::Mat{N, M, T}, i::Int) = a[ind2sub((N,M), i)...]
 @inline getindex(A::FixedArray, I::Tuple) = map(IndexFunctor(A), I)
 
 @inline setindex(a::FixedArray, value, index::Int...) = map(SetindexFunctor(a, value, index), typeof(a))
 
 @inline column{N, T}(v::FixedVector{N, T}) = v
-@inline column{R, C, T}(a::Mat{R, C, T}, i::Union{Range, Int}) = a.(1)[i]
+@inline column{R, C, T}(a::Mat{R, C, T}, i::Union{Range, Int}) = a._[i]
 
 @inline row{N, T}(v::FixedVector{N, T}) = Mat{1, N, T}(v...)
 @inline row{N, T}(v::FixedVector{N, T}, i::Int) = (v[i],)
 @inline row{R, C, T}(a::Mat{R, C, T}, j::Int) = ntuple(IndexFunc(a, j), Val{C})::NTuple{C, T}
-@inline row{R, T}(a::Mat{R, 1, T}, j::Int) = (a.(1)[1][j],)
-@inline row{R, T}(a::Mat{R, 2, T}, j::Int) = (a.(1)[1][j], a.(1)[2][j])
-@inline row{R, T}(a::Mat{R, 3, T}, j::Int) = (a.(1)[1][j], a.(1)[2][j], a.(1)[3][j])
-@inline row{R, T}(a::Mat{R, 4, T}, j::Int) = (a.(1)[1][j], a.(1)[2][j], a.(1)[3][j], a.(1)[4][j],)
+@inline row{R, T}(a::Mat{R, 1, T}, j::Int) = (a._[1][j],)
+@inline row{R, T}(a::Mat{R, 2, T}, j::Int) = (a._[1][j], a._[2][j])
+@inline row{R, T}(a::Mat{R, 3, T}, j::Int) = (a._[1][j], a._[2][j], a._[3][j])
+@inline row{R, T}(a::Mat{R, 4, T}, j::Int) = (a._[1][j], a._[2][j], a._[3][j], a._[4][j],)
 
 
 # the columns of the ctranspose are the complex conjugate rows
 @inline crow{R, C, T}(a::Mat{R, C, T}, j::Int) = ntuple(IndexFunc(a, j)', Val{C})::NTuple{C, T}
-@inline crow{R, T}(a::Mat{R, 1, T}, j::Int) = (a.(1)[1][j]',)
-@inline crow{R, T}(a::Mat{R, 2, T}, j::Int) = (a.(1)[1][j]', a.(1)[2][j]')
-@inline crow{R, T}(a::Mat{R, 3, T}, j::Int) = (a.(1)[1][j]', a.(1)[2][j]', a.(1)[3][j]')
-@inline crow{R, T}(a::Mat{R, 4, T}, j::Int) = (a.(1)[1][j]', a.(1)[2][j]', a.(1)[3][j]', a.(1)[4][j]',)
+@inline crow{R, T}(a::Mat{R, 1, T}, j::Int) = (a._[1][j]',)
+@inline crow{R, T}(a::Mat{R, 2, T}, j::Int) = (a._[1][j]', a._[2][j]')
+@inline crow{R, T}(a::Mat{R, 3, T}, j::Int) = (a._[1][j]', a._[2][j]', a._[3][j]')
+@inline crow{R, T}(a::Mat{R, 4, T}, j::Int) = (a._[1][j]', a._[2][j]', a._[3][j]', a._[4][j]',)
 
 
 # Unified slicing along combinations of fixed and variable dimensions

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -12,9 +12,9 @@ end
 @inline function reduce(f::Functor{2}, a::Mat)
     length(a) == 1 && return a[1,1]
     @inbounds begin
-        red = reduce(f, a.(1)[1])
+        red = reduce(f, a._[1])
         for i=2:size(a, 2)
-            red = f(red, reduce(f, a.(1)[i]))
+            red = f(red, reduce(f, a._[i]))
         end
     end
     red

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -262,7 +262,7 @@ end
 end
 
 @generated function *{T, M, N}(a::Mat{M, N, T}, b::Vec{N,T})
-    expr = [:(bilindot(row(a, $i), b.(1))) for i=1:M]
+    expr = [:(bilindot(row(a, $i), b._)) for i=1:M]
     :( Vec($(expr...)) )
 end
 @generated function *{T, M, N, R}(a::Mat{M, N, T}, b::Mat{N, R, T})
@@ -280,10 +280,10 @@ function (==)(a::FixedVectorNoTuple, b::FixedVectorNoTuple)
     end
     true
 end
-(==)(a::FixedArray, b::FixedArray) = a.(1) == b.(1)
+(==)(a::FixedArray, b::FixedArray) = a._ == b._
 
-(==){R, T, FSA <: FixedVector}(a::FSA, b::Mat{R, 1, T}) = a.(1) == column(b,1)
-(==){R, T, FSA <: FixedVector}(a::Mat{R, 1, T}, b::FSA) = column(a,1) == b.(1)
+(==){R, T, FSA <: FixedVector}(a::FSA, b::Mat{R, 1, T}) = a._ == column(b,1)
+(==){R, T, FSA <: FixedVector}(a::Mat{R, 1, T}, b::FSA) = column(a,1) == b._
 function (==)(a::FixedArray, b::AbstractArray)
     s_a = size(a)
     s_b = size(b)


### PR DESCRIPTION
Fix a whole bunch of deprecations due to recent changes in 0.5 which deprecated the alias `x.(i)`.  (These depwarns result in horrible generated code in 0.5.)

Note that these changes now assume that for normal `FixedArray` (not `FixedVectorNoTuple`) the tuple storage has the name `_`.  I don't see how this can hurt since `FixedSizeArrays` already has a lot of assumptions about the internal structure of user-defined `FixedArray` types, so it seems to make sense to be opinionated about this, but do let me know if `getfield(x,1)` would be better for some reason.
