### PR TITLE
similar_type implementation

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -22,11 +22,8 @@ end
 immutable Mat{Row, Column, T} <: FixedMatrix{Row, Column, T}
     _::NTuple{Column, NTuple{Row, T}}
 end
-function similar{FSA <: Mat, T}(::Type{FSA}, ::Type{T}, SZ::NTuple{2, Int})
-    Mat{SZ[1], SZ[2], T}
-end
-similar{FSA <: Mat}(::Type{FSA}, SZ::NTuple{2,Int}) = similar(FSA, eltype(FSA), SZ)
-similar{N,M,S, T}(::Type{Mat{N,M,S}}, ::Type{T}) = Mat{N,M,T}
+similar_type{FSA<:Mat,T}(::Type{FSA}, ::Type{T}, sz::NTuple{2, Int}) = Mat{sz[1], sz[2], T}
+similar_type{N,M,S, T}(::Type{Mat{N,M,S}}, ::Type{T}) = Mat{N,M,T}
 
 # most common FSA types
 immutable Vec{N, T} <: FixedVector{N, T}
@@ -35,6 +32,7 @@ end
 immutable Point{N, T} <: FixedVector{N, T}
     _::NTuple{N, T}
 end
+similar_type{FSA<:Point,T}(::Type{FSA}, ::Type{T}, sz::Tuple{Int}) = Point{sz[1],T}
 
 include("mapreduce.jl")
 include("destructure.jl")
@@ -70,6 +68,7 @@ export MutableFixedVector
 export MutableFixedMatrix
 export Mat, Vec, Point
 export @fsa
+export similar_type
 export construct_similar
 
 export unit

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -30,7 +30,6 @@ include("constructors.jl")
 immutable Mat{Row, Column, T} <: FixedMatrix{Row, Column, T}
     _::NTuple{Column, NTuple{Row, T}}
 end
-@pure similar_type{FSA<:Mat,T}(::Type{FSA}, ::Type{T}, sz::NTuple{2, Int}) = Mat{sz[1], sz[2], T}
 
 # most common FSA types
 immutable Vec{N, T} <: FixedVector{N, T}
@@ -39,7 +38,6 @@ end
 immutable Point{N, T} <: FixedVector{N, T}
     _::NTuple{N, T}
 end
-@pure similar_type{FSA<:Point,T}(::Type{FSA}, ::Type{T}, sz::Tuple{Int}) = Point{sz[1],T}
 
 include("mapreduce.jl")
 include("destructure.jl")

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -9,21 +9,28 @@ import Base.LinAlg.chol!
 # for 0.5 and 0.4 compat, use our own functor type
 abstract Functor{N}
 
-include("core.jl")
-include("functors.jl")
-include("constructors.jl")
-
 if VERSION <= v"0.5.0"
     supertype(x) = super(x)
 end
+
+if VERSION < v"0.5.0-dev+698"
+    macro pure(ex)
+        esc(ex)
+    end
+else
+    import Base: @pure
+end
+
+include("core.jl")
+include("functors.jl")
+include("constructors.jl")
 
 # put them here due to #JuliaLang/julia#12814
 # needs to be before indexing and ops, but after constructors
 immutable Mat{Row, Column, T} <: FixedMatrix{Row, Column, T}
     _::NTuple{Column, NTuple{Row, T}}
 end
-similar_type{FSA<:Mat,T}(::Type{FSA}, ::Type{T}, sz::NTuple{2, Int}) = Mat{sz[1], sz[2], T}
-similar_type{N,M,S, T}(::Type{Mat{N,M,S}}, ::Type{T}) = Mat{N,M,T}
+@pure similar_type{FSA<:Mat,T}(::Type{FSA}, ::Type{T}, sz::NTuple{2, Int}) = Mat{sz[1], sz[2], T}
 
 # most common FSA types
 immutable Vec{N, T} <: FixedVector{N, T}
@@ -32,7 +39,7 @@ end
 immutable Point{N, T} <: FixedVector{N, T}
     _::NTuple{N, T}
 end
-similar_type{FSA<:Point,T}(::Type{FSA}, ::Type{T}, sz::Tuple{Int}) = Point{sz[1],T}
+@pure similar_type{FSA<:Point,T}(::Type{FSA}, ::Type{T}, sz::Tuple{Int}) = Point{sz[1],T}
 
 include("mapreduce.jl")
 include("destructure.jl")

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -77,7 +77,7 @@ and overwrites the default constructor.
     end
     SZ      = size_or(FSA, (orlen, ntuple(x->1, ND-1)...))::NTuple{ND, Int}
     T       = eltype_or(FSA, ortyp)::DataType
-    FSAT    = similar(FSA, T, SZ)
+    FSAT    = similar_type(FSA, T, SZ)
     if X <: Tuple
         expr = fill_tuples_expr((inds...)->:($T(a[$(inds[1])])), SZ)
     else

--- a/src/core.jl
+++ b/src/core.jl
@@ -78,14 +78,6 @@ done(A::FixedArray, state::Integer) = length(A) < state
     :($(T.name.primary))
 end
 
-if VERSION < v"0.5.0-dev+698"
-    macro pure(ex)
-        esc(ex)
-    end
-else
-    import Base: @pure
-end
-
 @pure function similar_type{FSA <: FixedArray, T}(::Type{FSA}, ::Type{T}, n::Tuple)
     # Exact match - return the same type again
     if eltype(FSA) == T && n == size(FSA)
@@ -101,12 +93,9 @@ end
     end
 end
 
-# Versions with defaults
+# Versions with defaulted eltype and size
 @pure similar_type{FSA <: FixedArray, T}(::Type{FSA}, ::Type{T}) = similar_type(FSA, T, size(FSA))
 @pure similar_type{FSA <: FixedArray}(::Type{FSA}, sz::Tuple) = similar_type(FSA, eltype(FSA), sz)
-
-# Convenience function
-@pure similar_type{FSA <: FixedArray, T}(::Type{FSA}, ::Type{T}, sz::Int...) = similar_type(FSA, T, sz)
 
 
 @generated function get_tuple{N, T}(f::FixedVectorNoTuple{N, T})

--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -124,12 +124,6 @@ end
 @generated function map{F<:FixedArray}(func, arg1::F)
     unrolled_map_expr(:func, SimilarTo{arg1}, size(F), (arg1,), (:arg1,))
 end
-# Unary versions for type conversion.  Need to override these explicitly to
-# prevent conflicts with Base.
-@inline map{T,N,S}(::Type{T}, arg1::FixedArray{T,N,S}) = arg1 # nop version
-immutable ConstructTypeFun{T}; end
-call{T}(::ConstructTypeFun{T}, x) = T(x)
-@inline map{T,FSA<:FixedArray}(::Type{T}, arg1::FSA) = map(ConstructTypeFun{T}(), similar(FSA, T), arg1)
 
 
 # Nullary special case version.

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -18,9 +18,13 @@ immutable RGB{T} <: FixedVectorNoTuple{3, T}
         new{T}(a[1], a[2], a[3])
     end
 end
+function FixedSizeArrays.similar_type{FSA<:RGB,T}(::Type{FSA}, ::Type{T}, n::Tuple{Int})
+    n[1] == 3 ? RGB{T} : similar_type(FixedArray, T, n)
+end
+
 # subtyping:
 immutable TestType{N,T} <: FixedVector{N,T}
-    a::NTuple{N,T}
+    _::NTuple{N,T}
 end
 
 
@@ -115,16 +119,16 @@ context("core") do
 
         @fact ndims_or(FixedArray, nothing) --> nothing
     end
-    context("similar") do
-        @fact similar(Vec{3}, Float32) --> Vec{3, Float32}
-        @fact similar(Vec, Float32, 3) --> Vec{3, Float32}
+    context("similar_type") do
+        @fact similar_type(Vec{3}, Float32) --> Vec{3, Float32}
+        @fact similar_type(Vec, Float32, 3) --> Vec{3, Float32}
 
-        @fact similar(RGB, Float32) --> RGB{Float32}
-        @fact similar(RGB{Float32}, Int) --> RGB{Int}
+        @fact similar_type(RGB, Float32) --> RGB{Float32}
+        @fact similar_type(RGB{Float32}, Int) --> RGB{Int}
 
-        @fact similar(Mat{3,3,Int}, Float32) --> Mat{3,3,Float32}
-        @fact similar(Mat, Float32, (3,3))   --> Mat{3,3,Float32}
-        @fact similar(Mat{2,2,Int}, (3,3))   --> Mat{3,3,Int}
+        @fact similar_type(Mat{3,3,Int}, Float32) --> Mat{3,3,Float32}
+        @fact similar_type(Mat, Float32, (3,3))   --> Mat{3,3,Float32}
+        @fact similar_type(Mat{2,2,Int}, (3,3))   --> Mat{3,3,Int}
     end
 
     context("construct_similar") do
@@ -1145,7 +1149,7 @@ end
 
 facts("show for subtype") do
 
-    Base.show(io::IO, x::TestType) = print(io, "$(x.a)")  # show for new type
+    Base.show(io::IO, x::TestType) = print(io, "$(x._)")  # show for new type
 
     x = TestType(1, 2)
     @fact string(x) --> "(1,2)"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -20,22 +20,16 @@ immutable RGB{T} <: FixedVectorNoTuple{3, T}
         new{T}(a[1], a[2], a[3])
     end
 end
-function similar_type{FSA<:RGB,T}(::Type{FSA}, ::Type{T}, n::Tuple{Int})
-    n[1] == 3 ? RGB{T} : similar_type(FixedArray, T, n)
-end
 
 # subtyping:
 immutable TestType{N,T} <: FixedVector{N,T}
     _::NTuple{N,T}
 end
 
-# Test similar_type usage for custom FSA with non-parameterized size and eltype
+# Custom FSA with non-parameterized size and eltype
 immutable Coord2D <: FixedVectorNoTuple{2,Float64}
     x::Float64
     y::Float64
-end
-function similar_type{T}(::Type{Coord2D}, ::Type{T}, n::Tuple{Int})
-    n[1] == 2 && T == Float64 ? Coord2D : similar_type(FixedArray, T, n)
 end
 
 
@@ -130,16 +124,25 @@ context("core") do
 
         @fact ndims_or(FixedArray, nothing) --> nothing
     end
+
     context("similar_type") do
+        @fact similar_type(Vec{3,Int}, Float32) --> Vec{3, Float32}
         @fact similar_type(Vec{3}, Float32) --> Vec{3, Float32}
         @fact similar_type(Vec, Float32, (3,)) --> Vec{3, Float32}
+        @fact similar_type(Vec, Float32, (1,2)) --> Mat{1,2, Float32}
 
         @fact similar_type(RGB, Float32) --> RGB{Float32}
         @fact similar_type(RGB{Float32}, Int) --> RGB{Int}
+        @fact similar_type(RGB{Float32}, Int, (3,)) --> RGB{Int}
+        @fact similar_type(RGB{Float32}, Int, (2,2)) --> Mat{2,2,Int}
 
         @fact similar_type(Mat{3,3,Int}, Float32) --> Mat{3,3,Float32}
         @fact similar_type(Mat, Float32, (3,3))   --> Mat{3,3,Float32}
         @fact similar_type(Mat{2,2,Int}, (3,3))   --> Mat{3,3,Int}
+
+        @fact similar_type(Coord2D, Float64, (2,)) --> Coord2D
+        @fact similar_type(Coord2D, Int, (2,))     --> Vec{2,Int}
+        @fact similar_type(Coord2D, Float64, (3,)) --> Vec{3,Float64}
     end
 
     context("construct_similar") do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -132,7 +132,7 @@ context("core") do
     end
     context("similar_type") do
         @fact similar_type(Vec{3}, Float32) --> Vec{3, Float32}
-        @fact similar_type(Vec, Float32, 3) --> Vec{3, Float32}
+        @fact similar_type(Vec, Float32, (3,)) --> Vec{3, Float32}
 
         @fact similar_type(RGB, Float32) --> RGB{Float32}
         @fact similar_type(RGB{Float32}, Int) --> RGB{Int}


### PR DESCRIPTION
As discussed in #116, I've had a crack at replacing `similar` with `similar_type`.  I think this is more systematic than what we've got now, but it still may not quite be right.  I'm open to other ways to define the default implementation of `similar_type`, but it's clear to me that any default implementation has problems for one case or other.  Again, see #116 for some other options.

I also had a go at updating the readme for this, and also to document the types which are defined and address the uncertainty around what `Point` actually is meant to represent.
