### PR TITLE
Linear algebra for general matrix and vector types

### DIFF
--- a/src/ops.jl
+++ b/src/ops.jl
@@ -134,21 +134,34 @@ end
 
 immutable DotFunctor <: Functor{2} end
 call(::DotFunctor, a, b) = a'*b
-@inline dot{T <:  FixedArray}(a::T, b::T) = sum(map(DotFunctor(), a, b))
+@inline dot{T, N}(a::FixedArray{T,1,Tuple{N}}, b::FixedArray{T,1,Tuple{N}}) = sum(map(DotFunctor(), a, b))
+@inline dot{T1, T2, N}(a::FixedArray{T1,1,Tuple{N}}, b::FixedArray{T2,1,Tuple{N}}) = sum(map(DotFunctor(), promote(a, b)...))
 
 immutable BilinearDotFunctor <: Functor{2} end
 call(::BilinearDotFunctor, a, b) = a*b
 @inline bilindot{T <: Union{FixedArray, Tuple}}(a::T, b::T) = sum(map(BilinearDotFunctor(), a, b))
-@inline bilindot{T1 <: Tuple, T2 <: FixedArray}(a::T1, b::T2) = sum(map(BilinearDotFunctor(), a, b))
 
-@inline bilindot{T}(a::NTuple{1,T}, b::NTuple{1,T}) = @inbounds return a[1]*b[1]
-@inline bilindot{T}(a::NTuple{2,T}, b::NTuple{2,T}) = @inbounds return (a[1]*b[1] + a[2]*b[2])
-@inline bilindot{T}(a::NTuple{3,T}, b::NTuple{3,T}) = @inbounds return (a[1]*b[1] + a[2]*b[2] + a[3]*b[3])
-@inline bilindot{T}(a::NTuple{4,T}, b::NTuple{4,T}) = @inbounds return (a[1]*b[1] + a[2]*b[2] + a[3]*b[3]+a[4]*b[4])
+@inline bilindot{T, N}(a::FixedArray{T,1,Tuple{N}}, b::FixedArray{T,1,Tuple{N}}) = sum(map(DotFunctor(), a, b))
+@inline bilindot{T1, T2, N}(a::FixedArray{T1,1,Tuple{N}}, b::FixedArray{T2,1,Tuple{N}}) = sum(map(DotFunctor(), promote(a, b)...))
+
+@inline bilindot{T, N}(a::FixedArray{T,1,Tuple{N}}, b::NTuple{N,T}) = sum(map(DotFunctor(), a, b))
+@inline bilindot{T1, T2, N}(a::FixedArray{T1,1,Tuple{N}}, b::NTuple{N,T2}) = sum(map(DotFunctor(), promote(a, b)...))
+
+@inline bilindot{T, N}(a::NTuple{N,T}, b::FixedArray{T,1,Tuple{N}}) = sum(map(DotFunctor(), a, b))
+@inline bilindot{T1, T2, N}(a::NTuple{N,T1}, b::FixedArray{T2,1,Tuple{N}}) = sum(map(DotFunctor(), promote(a, b)...))
+
+
+@inline bilindot{T1, T2}(a::NTuple{1,T1}, b::NTuple{1,T2}) = @inbounds return a[1]*b[1]
+@inline bilindot{T1, T2}(a::NTuple{2,T1}, b::NTuple{2,T2}) = @inbounds return (a[1]*b[1] + a[2]*b[2])
+@inline bilindot{T1, T2}(a::NTuple{3,T1}, b::NTuple{3,T2}) = @inbounds return (a[1]*b[1] + a[2]*b[2] + a[3]*b[3])
+@inline bilindot{T1, T2}(a::NTuple{4,T1}, b::NTuple{4,T2}) = @inbounds return (a[1]*b[1] + a[2]*b[2] + a[3]*b[3]+a[4]*b[4])
+@inline bilindot{T1, T2, N}(a::NTuple{N,T1}, b::NTuple{N,T2}) = sum(map(DotFunctor(), promote(a, b)...))
+
+
 
 
 #cross{T}(a::FixedVector{2, T}, b::FixedVector{2, T}) = a[1]*b[2]-a[2]*b[1] # not really used!?
-@inline cross{T<:Number}(a::FixedVector{3, T}, b::FixedVector{3, T}) = @inbounds return typeof(a)(
+@inline cross{T1 <: Number, T2 <: Number}(a::FixedVector{3, T1}, b::FixedVector{3, T2}) = @inbounds return similar(typeof(a), promote_type(T1, T2))(
     a[2]*b[3]-a[3]*b[2],
     a[3]*b[1]-a[1]*b[3],
     a[1]*b[2]-a[2]*b[1]
@@ -189,7 +202,7 @@ trace(A::FixedMatrix{2,2}) = A[1,1] + A[2,2]
 trace(A::FixedMatrix{3,3}) = A[1,1] + A[2,2] + A[3,3]
 trace(A::FixedMatrix{4,4}) = A[1,1] + A[2,2] + A[3,3] + A[4,4]
 
-\{m,n,T}(mat::Mat{m,n,T}, v::Vec{n, T}) = inv(mat)*v
+\{m,n,T1,T2}(mat::Mat{m,n,T1}, v::Vec{n,T2}) = inv(mat)*v
 
 @inline inv{T}(A::Mat{1, 1, T}) = @inbounds return Mat{1, 1, T}(inv(A[1]))
 @inline function inv{T}(A::Mat{2, 2, T})
@@ -267,24 +280,25 @@ chol!(m::Mat, ::Type{UpperTriangular}) = chol(m)
 chol!(m::Mat, ::Type{Val{:U}}) = chol!(m, UpperTriangular)
 
 # Matrix
-(*){T, M, N, O, K}(a::FixedMatrix{M, N, T}, b::FixedMatrix{O, K, T}) = throw(DimensionMismatch("$N != $O in $(typeof(a)) and $(typeof(b))"))
-(*){T, M, N, O}(a::FixedMatrix{M, N, T}, b::FixedVector{O, T}) = throw(DimensionMismatch("$N != $O in $(typeof(a)) and $(typeof(b))"))
+(*){T1, T2, M, N, O, K}(a::FixedMatrix{M, N, T1}, b::FixedMatrix{O, K, T2}) = throw(DimensionMismatch("$N != $O in $(typeof(a)) and $(typeof(b))"))
+(*){T1, T2, M, N, O}(a::FixedMatrix{M, N, T1}, b::FixedVector{O, T2}) = throw(DimensionMismatch("$N != $O in $(typeof(a)) and $(typeof(b))"))
 
-@generated function *{T, N}(a::FixedVector{N, T}, b::FixedMatrix{1, N, T})
+@generated function *{T1, T2, N}(a::FixedVector{N, T1}, b::FixedMatrix{1, N, T2})
     expr = Expr(:tuple, [Expr(:tuple, [:(a[$i] * b[$j]) for i in 1:N]...) for j in 1:N]...)
     :( Mat($(expr)) )
 end
 
-@generated function *{T, M, N}(a::Mat{M, N, T}, b::FixedVectorNoTuple{N, T})
-    expr = [:(bilindot(row(a, $i), b)) for i=1:M]
-    :( Vec{M, T}($(expr...)))
+@generated function *{T1, T2, M, N}(a::Mat{M, N, T1}, b::FixedVectorNoTuple{N, T2})
+    oT = promote_type(T1, T2)
+    expr = [:(bilindot(row(a, $i), b)::$(oT)) for i=1:M]
+    :( Vec{$(M), $(oT)}($(expr...)))
 end
 
-@generated function *{T, M, N}(a::Mat{M, N, T}, b::Vec{N,T})
+@generated function *{T1, T2, M, N}(a::Mat{M, N, T1}, b::Vec{N,T2})
     expr = [:(bilindot(row(a, $i), b._)) for i=1:M]
     :( Vec($(expr...)) )
 end
-@generated function *{T, M, N, R}(a::Mat{M, N, T}, b::Mat{N, R, T})
+@generated function *{T1, T2, M, N, R}(a::Mat{M, N, T1}, b::Mat{N, R, T2})
     expr = Expr(:tuple, [Expr(:tuple, [:(bilindot(row(a, $i), column(b,$j))) for i in 1:M]...) for j in 1:R]...)
     :( Mat($(expr)) )
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -936,6 +936,8 @@ context("Matrix Math") do
 			@fact isapprox(@inferred(mifs * vfs), vmi)  --> true
 			vmi = m * vi
 			@fact isapprox(@inferred(mfs * vifs), vmi)  --> true
+			# Custom vector types
+			@fact @inferred(eye(Mat{3,3,Float64}) * RGB{Int}(1,2,3)) --> exactly(RGB{Float64}(1,2,3))
 		end
 		context("Matrix{$i, $j, T} * Matrix{$j, $i, U}") do
 			mmi = mi * m2'
@@ -943,7 +945,6 @@ context("Matrix Math") do
 			mmi = m * mi2'
 			@fact isapprox(@inferred(mfs * mi2fs'), mmi)  --> true
 		end
-
 
 		if i == j
             context("(2*I + I*M)\\v") do

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -470,6 +470,7 @@ end
 
 v2 = Vec(6.0,5.0,4.0)
 v1 = Vec(1.0,2.0,3.0)
+vi = Vec(1,2,3)
 v2 = Vec(6.0,5.0,4.0)
 v1c = Vec(6.0+3.0im,5.0-2im,4.0+0.0im)
 v2c = v1 + v2*im
@@ -621,6 +622,9 @@ context("Ops") do
 	context("Multiplication") do
 		@fact @inferred(v1.*v2) --> Vec3d(6.0,10.0,12.0)
 	end
+    context("Mixed Type Multiplication") do
+		@fact @inferred(vi.*v2) --> Vec3d(6.0,10.0,12.0)
+	end
 	context("Division") do
 		@fact @inferred(v1 ./ v1) --> Vec3d(1.0,1.0,1.0)
 	end
@@ -688,6 +692,9 @@ context("Ops") do
         # cross product
         @fact cross(v1,v2) --> Vec3d(-7.0,14.0,-7.0)
         @fact isa(cross(v1,v2),Vec3d)  --> true
+
+        @fact cross(vi,v2) --> Vec3d(-7.0,14.0,-7.0)
+        @fact isa(cross(vi,v2),Vec3d)  --> true
     end
 
     context("hypot") do
@@ -903,6 +910,13 @@ context("Matrix Math") do
         m2fs = Mat(m2)
         mfsc = Mat(mc)
 
+        vi = randperm(j)
+        mi = reshape(randperm(i*j), i, j)
+        mi2 = reshape(randperm(i*j), i, j)
+        vifs = Vec(vi)
+        mifs = Mat(mi)
+        mi2fs = Mat(mi2)
+
 		context("Matrix{$i, $j} * Vector{$j}") do
 			vm = m * v
 			@fact isapprox(@inferred(mfs * vfs), vm)  --> true
@@ -916,6 +930,21 @@ context("Matrix Math") do
 			@fact isapprox(@inferred(m*(2I)), mm)  --> true
 		end
 
+		# test different element types
+		context("Matrix{$i, $j, T} * Vector{$j, U}") do
+			vmi = mi * v
+			@fact isapprox(@inferred(mifs * vfs), vmi)  --> true
+			vmi = m * vi
+			@fact isapprox(@inferred(mfs * vifs), vmi)  --> true
+		end
+		context("Matrix{$i, $j, T} * Matrix{$j, $i, U}") do
+			mmi = mi * m2'
+			@fact isapprox(@inferred(mifs * m2fs'), mmi)  --> true
+			mmi = m * mi2'
+			@fact isapprox(@inferred(mfs * mi2fs'), mmi)  --> true
+		end
+
+
 		if i == j
             context("(2*I + I*M)\\v") do
 			    mm = (2*I+I*m) \ v
@@ -926,11 +955,11 @@ context("Matrix Math") do
 				fmm = det(mfs)
 				@fact isapprox(fmm, mm)  --> true
 			end
-                        context("trace(M)") do
-                                mm = trace(m)
-                                fmm = trace(mfs)
-                                @fact isapprox(fmm, mm)  --> true
-                        end
+            context("trace(M)") do
+				mm = trace(m)
+				fmm = trace(mfs)
+				@fact isapprox(fmm, mm)  --> true
+            end
 			context("inv(M)") do
 				mm = inv(m)
 				fmm = inv(mfs)
@@ -964,7 +993,6 @@ context("Matrix Math") do
                 @fact_throws DimensionMismatch mfs * mfs
             end
         end
-
 		context("transpose M") do
 			mm = m'
 			fmm = mfs'
@@ -1009,13 +1037,16 @@ end
 
 
 ac = rand(3)
+aci = randperm(3)
 bc = rand(3)
+
 
 a = rand(4)
 b = rand(4)
 c = rand(4,4)
 
 d = cross(ac, bc)
+di = cross(aci, bc)
 d2 = a+b
 f = c*a
 g = c*b
@@ -1026,6 +1057,7 @@ k = abs(f)
 l = abs(-f)
 
 acfs = Vec(ac)
+acifs = Vec(aci)
 bcfs = Vec(bc)
 
 afs = Vec(a)
@@ -1033,6 +1065,7 @@ bfs = Vec(b)
 cfs = Mat(c)
 
 dfs = cross(acfs, bcfs)
+difs = cross(acifs, bcfs)
 d2fs = afs+bfs
 ffs = cfs*afs
 gfs = cfs*bfs
@@ -1058,6 +1091,7 @@ context("Vector Math") do
         @fact isapprox(cfs, c) --> true
 
         @fact isapprox(dfs, d) --> true
+        @fact isapprox(difs, di) --> true
         @fact isapprox(d2fs, d2) --> true
         @fact isapprox(ffs, f) --> true
         @fact isapprox(gfs, g) --> true


### PR DESCRIPTION
@awbsmith this includes your changes from #98 but modified for the new map infrastructure.  It should clean up linear algebra with FSAs a fair bit.

The major implementation change here is to use construct_similar rather than assuming the output vector type, and to just unroll the product entirely rather than emitting a bunch of calls to bilindot().  As a result, a bunch of bilindot stuff can be removed since we don't need to extract rows of the matrix as tuples.  (I guess this is good, though it may result in rather some code bloat for larger FSAs.  Can't really be solved properly until we get setindex() on a Ref or some such thing.)

Demo:

``` julia
julia> using FixedSizeArrays

julia> immutable RGB{T} <: FixedVectorNoTuple{3, T}
           r::T
           g::T
           b::T
       end

julia> M = eye(Mat{3,3,Float64})
FixedSizeArrays.Mat{3,3,Float64}(
    1.0 0.0 0.0
    0.0 1.0 0.0
    0.0 0.0 1.0
)

julia> M * RGB(1,2,3)
RGB(1.0,2.0,3.0)
```

I think the fact that we can get an RGB back here is pretty cool.
