### PR TITLE
Added ability for mixed-matrix-multiplication

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -920,10 +920,14 @@ context("Matrix Math") do
 		context("Matrix{$i, $j} * Vector{$j}") do
 			vm = m * v
 			@fact isapprox(@inferred(mfs * vfs), vm)  --> true
+            @fact isapprox(@inferred(Matrix(mfs) * vfs), vm)  --> true
+            @fact isapprox(@inferred(mfs * Vector(vfs)), vm)  --> true
 		end
         context("Matrix{$i, $j} * Matrix{$j, $i}") do
 			mm = m * m2'
 			@fact isapprox(@inferred(mfs * m2fs'), mm)  --> true
+            @fact isapprox(@inferred(Matrix(mfs) * m2fs'), mm)  --> true
+            @fact isapprox(@inferred(mfs * Matrix(m2fs')), mm)  --> true
 		end
         context("Matrix{$i, $j}*(2I)") do
 			mm = m*(2)


### PR DESCRIPTION
Can now multiply a fixed-size matrix/vector with a standard matrix/vector and hopefully it should all work out OK.

Assumptions: 
- If necessary, your `FixedArray` is assumed to be dense and simply converted to `Array` before multiplication. This may be efficient in certain circumstances and less efficient in others.
- `FixedMatrix{M,N} * Vector` results in `Vec{M}`, which seems safer than trying to follow the type of the matrix.

These seem reasonable to me but I welcome feedback.
