### PR TITLE
Proper constructors for FixedVectorNoTuple

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,6 @@ immutable RGB{T} <: FixedVectorNoTuple{3, T}
     r::T
     g::T
     b::T
-    function RGB(a::NTuple{3, T}) #needs to be like this to keep constructor code sane
-        new{T}(a[1], a[2], a[3])
-    end
 end
 immutable Vec{N, T} <: FixedVector{N, T} # defined in FixedSizeArrays already
     _::NTuple{N, T}

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -103,6 +103,10 @@ E.g. 1, 2f0, 4.0
 end
 
 @generated function call{FSV <: FixedVectorNoTuple, N}(::Type{FSV}, a::FixedVector{N})
+    if length(FSV) != N
+        message = "length($FSV) != length($a))"
+        return :(throw(DimensionMismatch($message)))
+    end
     return Expr(:call, FSV, ntuple(i->:(a[$i]), N)...)
 end
 

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -1,8 +1,8 @@
 
 _fill_tuples_expr(inner::Function, SZ::Tuple{Int}, inds...) =
-    :(tuple($(ntuple(i->inner(i, inds...), SZ[1])...)))
+    Expr(:tuple, ntuple(i->inner(i, inds...), SZ[1])...)
 _fill_tuples_expr{N}(inner::Function, SZ::NTuple{N, Int}, inds...) =
-    :(tuple($(ntuple(i->_fill_tuples_expr(inner, SZ[1:end-1], i, inds...),SZ[end])...)))
+    Expr(:tuple, ntuple(i->_fill_tuples_expr(inner, SZ[1:end-1], i, inds...),SZ[end])...)
 fill_tuples_expr(inner::Function, SZ::Tuple) = _fill_tuples_expr(inner, SZ)
 
 
@@ -83,7 +83,11 @@ and overwrites the default constructor.
     else
         expr = fill_tuples_expr((inds...)->:($T(a)), SZ)
     end
-    return :($FSAT($expr))
+    if FSAT <: FixedVectorNoTuple
+        return Expr(:call, FSAT, expr.args...)
+    else
+        return :($FSAT($expr))
+    end
 end
 
 """
@@ -96,6 +100,10 @@ E.g. 1, 2f0, 4.0
     all(x-> x <: Tuple, a) && return :( $FSA(a) ) # TODO be smarter about this
     any(x-> x != ElType, a) && return :($FSA(map($ElType, a)))
     return :($FSA(a))
+end
+
+@generated function call{FSV <: FixedVectorNoTuple, N}(::Type{FSV}, a::FixedVector{N})
+    return Expr(:call, FSV, ntuple(i->:(a[$i]), N)...)
 end
 
 """

--- a/src/core.jl
+++ b/src/core.jl
@@ -162,7 +162,7 @@ function similar{FSA <: FixedArray}(::Type{FSA}, args...)
 end
 
 @generated function get_tuple{N, T}(f::FixedVectorNoTuple{N, T})
-    :(tuple($(ntuple(i->:(f[$i]), N)...)))
+    return Expr(:tuple, ntuple(i->:(f[$i]), N)...)
 end
 function get_tuple(f::FixedArray)
     f._
@@ -227,5 +227,3 @@ promoted element type of the nested tuple `elements`.
     converted_elements = convert_nested_tuple_expr(etype, :elements, elements)
     constructor_expr(outtype, converted_elements)
 end
-
-

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -16,9 +16,6 @@ immutable RGB{T} <: FixedVectorNoTuple{3, T}
     r::T
     g::T
     b::T
-    function RGB(a::NTuple{3, T})
-        new{T}(a[1], a[2], a[3])
-    end
 end
 
 # subtyping:
@@ -234,6 +231,7 @@ context("Constructor FixedVectorNoTuple") do
             @fact RGB(["0.222", "9.8822", "29.999"]) --> RGB{Float64}(0.222, 9.8822, 29.999)
             @fact typeof(map(RGB{Float32}, x))  --> Vector{RGB{Float32}}
             @fact RGB{T}(r)                     --> RGB(r,r,r)
+            @fact RGB{T}(Vec(r,r,r))            --> RGB(r,r,r)
             @fact RGB{T}([r,r,r])               --> RGB(r,r,r)
             @fact length(RGB{T}([r,r,r]))       --> 3
             @fact length(RGB{T})                --> 3


### PR DESCRIPTION
We now have an abstract constructor for `FixedVectorNoTuple`. Also fixed
up several other places where it might get confused and lead to
exceptions such as `StackOverflow`. Inner constructor for types like
`RGB` in the test suite are no-longer necessary after this change.
Finally, removed remaining use of the `tuple()` function.
