### PR TITLE
Use Compat to fix 0.5 depwarns for call()

### DIFF
--- a/src/array_of_fixedsize.jl
+++ b/src/array_of_fixedsize.jl
@@ -11,9 +11,9 @@ immutable MaxFunctor <: Functor{2} end
 immutable MinFunctor <: Functor{2} end
 immutable ExtremaFun <: Functor{2} end
 
-call(::MaxFunctor, a, b) = max(a, b)
-call(::MinFunctor, a, b) = min(a, b)
-call(::ExtremaFun, reducevalue, a) = min(reducevalue[1], a), max(reducevalue[2], a)
+@compat (::MaxFunctor)(a, b) = max(a, b)
+@compat (::MinFunctor)(a, b) = min(a, b)
+@compat (::ExtremaFun)(reducevalue, a) = min(reducevalue[1], a), max(reducevalue[2], a)
 
 minimum{T <: FixedArray}(a::Vector{T}) = reduce(MinFunctor(), a)
 maximum{T <: FixedArray}(a::Vector{T}) = reduce(MaxFunctor(), a)

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -55,7 +55,7 @@ function gen_functor(func::Symbol, unary::Int)
     arguments     = ntuple(i->Symbol("arg$i"), unary)
     functor_expr  = quote
         immutable $functor_name <: Functor{$unary} end
-        @inline call(::$functor_name, $(arguments...)) = $func($(arguments...))
+        @compat @inline (::$functor_name)($(arguments...)) = $func($(arguments...))
     end
     return (functor_name, functor_expr)
 end
@@ -133,11 +133,11 @@ end
 @inline Base.hypot{T}(v::FixedVector{2,T}) = hypot(v[1],v[2])
 
 immutable DotFunctor <: Functor{2} end
-call(::DotFunctor, a, b) = a'*b
+@compat (::DotFunctor)(a, b) = a'*b
 @inline dot(a::FixedVector, b::FixedVector) = sum(map(DotFunctor(), a, b))
 
 immutable BilinearDotFunctor <: Functor{2} end
-call(::BilinearDotFunctor, a, b) = a*b
+@compat (::BilinearDotFunctor)(a, b) = a*b
 @inline bilindot(a::FixedVector, b::FixedVector) = sum(map(BilinearDotFunctor(), a, b))
 
 


### PR DESCRIPTION
Just a few fixes for some new depwarns in 0.5.

Perhaps we should tag a new version after this?
