### PR TITLE
Add typed floor, ceil, trunc, round

### DIFF
--- a/src/ops.jl
+++ b/src/ops.jl
@@ -335,3 +335,9 @@ Base.Test.approx_full(a::FixedArray) = a
 +{m, n, T}(J::Base.LinAlg.UniformScaling, A::Mat{m,n, T}) = A + J
 -{m, n, T}(A::Mat{m,n, T}, J::Base.LinAlg.UniformScaling) = A + (-J)
 -{m, n, T}(J::Base.LinAlg.UniformScaling, A::Mat{m,n, T}) = J.λ*eye(Mat{m,n,T}) - A
+
+# typed floor, ceil, round, trunc
+Base.floor{T}(::Type{T}, A::FixedArray) = map(x->floor(T, x), A)
+Base.ceil{T}( ::Type{T}, A::FixedArray) = map(x->ceil( T, x), A)
+Base.trunc{T}(::Type{T}, A::FixedArray) = map(x->trunc(T, x), A)
+Base.round{T}(::Type{T}, A::FixedArray) = map(x->round(T, x), A)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1202,6 +1202,13 @@ context("mapping operators") do
     end
 end
 
+context("typed round/floor/ceil/trunc") do
+    v = Vec((0.8,1.2,-0.3))
+    @fact floor(Int, v) --> Vec((0,1,-1))
+    @fact ceil( Int, v) --> Vec((1,2,0))
+    @fact trunc(Int, v) --> Vec((0,1,0))
+    @fact round(Int, v) --> Vec((1,1,0))
+end
 
 context("Base.Test") do
     a = rand(2)


### PR DESCRIPTION
Tests don't seem to be passing on julia-0.5 (they break at `chol`), but I've verified that these particular lines work.
