### PR TITLE
Support for op-assign (+= -= etc) in @fslice

### DIFF
--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -593,8 +593,9 @@ context("Indexing") do
             rgb = RGB{Int}[RGB(i,2*i,3*i) for i=1:10]
 
             @fslice rgb[:r,:] = -1
+            @fslice rgb[:g,:] .+= 1
             @fslice rgb[3,:] = -3
-            @fact rgb --> RGB{Int}[RGB(-1,2*i,-3) for i=1:10]
+            @fact rgb --> RGB{Int}[RGB(-1,2*i+1,-3) for i=1:10]
         end
     end
 end


### PR DESCRIPTION
Support various opassignment syntax rather than only a simple `=`.  This
allows things like

```
@fslice A[1,:] += 1
```
