### PR TITLE
Use inbounds public interface for 0.5 compatibility

### DIFF
--- a/src/mapreduce.jl
+++ b/src/mapreduce.jl
@@ -78,9 +78,7 @@ function unrolled_map_expr(funcname, OutFSA, SIZE, argtypes, argnames)
     quote
         $(Expr(:meta, :inline))
         $(sizecheck...)
-        $(Expr(:boundscheck, false))
-        rvalue = $(constructor_expr(OutFSA, tuple_expr))
-        $(Expr(:boundscheck,:pop))
+        @inbounds rvalue = $(constructor_expr(OutFSA, tuple_expr))
         rvalue
     end
 end


### PR DESCRIPTION
The explicit `Expr(:boundscheck)` which is removed here is a 0.4
implementation detail.
