### PR TITLE
fix #135

### DIFF
--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -110,3 +110,7 @@ Examples:
 macro fslice(expr)
     fixed_slice_expr(expr)
 end
+
+@inline function Base.indexed_next(t::FixedVector, i::Int, state)
+    @inbounds return (t[i], i+1)
+end


### PR DESCRIPTION
turns out you need to overwrite this function to iterate fast without bounds checking!
