### PR TITLE
Core type rewrite

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,26 +65,29 @@ via an index.
 
 #### FixedArray concrete types
 
-The package currently provides three concrete FixedArray types
+The package currently provides five concrete FixedArray types
 
-  * `Vec{N,T}` is a length `N` vector of eltype `T`.
-  * `Mat{N,M,T}` is an `N×M` matrix of eltype `T`
+  * `Vec{N,T}` is a length `N` vector of element type `T`.
+  * `Mat{N,M,T}` is an `N×M` matrix of element type `T`
+  * `FArray3{N,M,P,T}` is an `N×M×P` array of element type `T`
+  * `FArray4{N,M,P,Q,T}` is an `N×M×P×Q` array of element type `T`
 
-These two types are intended to behave the same as `Base.Vector` and
-`Base.Matrix`, but with fixed size.  That is, the interface is a convenient
-union of elementwise array-like functionality and vector space / linear algebra
-operations.  Hopefully we'll have more general higher dimensional fixed size
-containers in the future (note that the total number of elements of a higher
-dimensional container quickly grows beyond the size where having a fixed stack
-allocated container really makes sense).
+These four types are intended to behave the same as `Base.Array` but with fixed
+size.  That is, the interface is a convenient union of elementwise array-like
+functionality and vector space / linear algebra operations.  Hopefully we'll
+have more general higher dimensional fixed size containers in the future (note
+that the total number of elements of a higher dimensional container quickly
+grows beyond the size where having a fixed stack allocated container really
+makes sense).
 
-  * `Point{N,T}` is a position type which is structurally identical to `Vec{N,T}`.
+  * `Point{N,T}` is a generic member of an `N`-dimensional Cartesian space with element type `T`.
 
-Semantically `Point{N,T}` should be used to represent position in an
-`N`-dimensional Cartesian space.  The distinction between this and `Vec` is
-particularly relevant when overloading functions which deal with geometric data.
-For instance, a geometric transformation applies differently depending on
-whether you're transforming a *position* (`Point`) versus a *direction* (`Vec`).
+`Point{N,T}` is structurally the same as `Vec{N,T}`, but should be used to
+represent position in an `N`-dimensional Cartesian space.  The distinction
+between this and `Vec` is particularly relevant when overloading functions which
+deal with geometric data.  For instance, a geometric transformation applies
+differently depending on whether you're transforming a *position* (`Point`)
+versus a *direction* (`Vec`).
 
 
 #### User-supplied functions for FixedArray subtypes

--- a/README.md
+++ b/README.md
@@ -46,21 +46,23 @@ Without FixedSizeArrays, this would end up in a lot of types which would all nee
 
 The package provides several abstract types:
 
-  * `FixedArray{T,NDim,SIZE}` is the abstract base type for all fixed
-    arrays.  `T` and `NDim` mirror the eltype and number of dimension type
-    parameters in `AbstractArray`.  In addition there's a `SIZE` Tuple which
-    defines the extent of each fixed dimension as an integer.
+  * `FixedArray{T,D}` is the abstract base type for all fixed arrays with
+    `T` the element type and `D` the number of dimensions.
+  * The subtypes `FixedArray1{N,T}`, `FixedArray2{N,M,T}`, `FixedArray3{N,M,P,T}`,
+    `FixedArray4{N,M,P,Q,T}`, are abstract base types for arrays of fixed
+    dimensionality, with dimensionalities between 1 and 4.  Higher
+    dimensionalities could be added easily if it made sense.  (Ideally we'd have
+    the fixed size type parameters in FixedArray itself, but it's not clear how we
+    can actually do this in a nice way.)
+  * `FixedVectorNoTuple{N, T}` is the abstract type to use when you'd like to
+    name the fields of a `FixedVector` explicitly rather than accessing them via
+    an index.
 
 There's some convenient type aliases:
 
-  * `FixedVector{N,T}` is a convenient type alias for a one dimensional fixed
-    vector of length `N` and eltype `T`.
-  * `FixedMatrix{N,M,T}` is a convenient type alias for a two dimensional fixed
-    matrix of size `(N,M)` and eltype `T`.
+  * `FixedVector{N,T}` is a type alias for `FixedArray1`.
+  * `FixedMatrix{N,M,T}` is a type alias for `FixedArray2`.
 
-Finally there's an abstract type `FixedVectorNoTuple{N, T}` for use when you'd
-like to name the fields of a `FixedVector` explicitly rather than accessing them
-via an index.
 
 
 #### FixedArray concrete types

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -11,7 +11,7 @@ import Base.LinAlg._chol!
 # for 0.5 and 0.4 compat, use our own functor type
 abstract Functor{N}
 
-if VERSION <= v"0.5.0"
+if VERSION < v"0.5.0-dev+1949"
     supertype(x) = super(x)
 end
 
@@ -26,20 +26,9 @@ end
 include("core.jl")
 include("functors.jl")
 include("constructors.jl")
-
-# put them here due to #JuliaLang/julia#12814
+# put concrete types here due to #JuliaLang/julia#12814
 # needs to be before indexing and ops, but after constructors
-immutable Mat{Row, Column, T} <: FixedMatrix{Row, Column, T}
-    values::NTuple{Column, NTuple{Row, T}}
-end
-
-# most common FSA types
-immutable Vec{N, T} <: FixedVector{N, T}
-    values::NTuple{N, T}
-end
-immutable Point{N, T} <: FixedVector{N, T}
-    values::NTuple{N, T}
-end
+include("concrete_types.jl")
 
 include("mapreduce.jl")
 include("destructure.jl")
@@ -68,12 +57,11 @@ function show{N,T}(io::IO, v::FixedVector{N,T})
 end
 
 export FixedArray
-export FixedVector
-export FixedMatrix
-export MutableFixedArray
-export MutableFixedVector
-export MutableFixedMatrix
-export Mat, Vec, Point
+export FixedArray1, FixedArray2, FixedArray3, FixedArray4, FixedArray5
+export FixedVector, FixedMatrix
+export FixedVectorNoTuple
+export Vec, Mat, Ar3, Ar4, Point
+
 export @fsa
 export similar_type
 export construct_similar

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -57,7 +57,7 @@ function show{N,T}(io::IO, v::FixedVector{N,T})
 end
 
 export FixedArray
-export FixedArray1, FixedArray2, FixedArray3, FixedArray4, FixedArray5
+export FixedArray1, FixedArray2, FixedArray3, FixedArray4
 export FixedVector, FixedMatrix
 export FixedVectorNoTuple
 export Vec, Mat, FArray3, FArray4, Point

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -60,7 +60,7 @@ export FixedArray
 export FixedArray1, FixedArray2, FixedArray3, FixedArray4, FixedArray5
 export FixedVector, FixedMatrix
 export FixedVectorNoTuple
-export Vec, Mat, Ar3, Ar4, Point
+export Vec, Mat, FArray3, FArray4, Point
 
 export @fsa
 export similar_type

--- a/src/concrete_types.jl
+++ b/src/concrete_types.jl
@@ -1,0 +1,44 @@
+#-------------------------------------------------------------------------------
+# Canonical fixed size array / linear algebra types
+"Canonical length-`N` vector with element type `T`"
+immutable Vec{N,T} <: FixedVector{N,T}
+    values::NTuple{N,T}
+end
+
+"Canonical N×M matrix with element type `T`"
+immutable Mat{N,M,T} <: FixedMatrix{N,M,T}
+    values::NTuple{M,NTuple{N,T}}
+end
+
+"Canonical rank three tensor with element type `T`"
+immutable Ar3{N,M,P,T} <: FixedArray3{N,M,P,T}
+    values::NTuple{P,NTuple{M,NTuple{N,T}}}
+end
+
+"Canonical rank four tensor with element type `T`"
+immutable Ar4{N,M,P,Q,T} <: FixedArray4{N,M,P,Q,T}
+    values::NTuple{Q,NTuple{P,NTuple{M,NTuple{N,T}}}}
+end
+
+
+# Return one of the standard array / linear algebra types above.
+@pure function default_similar_type{T}(::Type{T}, sz::Tuple)
+    if length(sz) == 1
+        return Vec{sz[1],T}
+    elseif length(sz) == 2
+        return Mat{sz[1],sz[2],T}
+    elseif length(sz) == 3
+        return Ar3{sz[1],sz[2],sz[3],T}
+    elseif length(sz) == 4
+        return Ar4{sz[1],sz[2],sz[3],sz[4],T}
+    else
+        throw(ArgumentError("No built in FixedArray type is implemented for eltype $T and size $sz"))
+    end
+end
+
+#-------------------------------------------------------------------------------
+# Other types
+"Generic member of an `N`-dimensional Cartesian space"
+immutable Point{N,T} <: FixedVector{N,T}
+    values::NTuple{N,T}
+end

--- a/src/concrete_types.jl
+++ b/src/concrete_types.jl
@@ -1,22 +1,38 @@
 #-------------------------------------------------------------------------------
 # Canonical fixed size array / linear algebra types
-"Canonical length-`N` vector with element type `T`"
+"""
+    Vec{N,T}
+
+Generic length-`N` vector with element type `T`
+"""
 immutable Vec{N,T} <: FixedVector{N,T}
     values::NTuple{N,T}
 end
 
-"Canonical N×M matrix with element type `T`"
+"""
+    Mat{N,M,T}
+
+Generic `N×M` matrix with element type `T`
+"""
 immutable Mat{N,M,T} <: FixedMatrix{N,M,T}
     values::NTuple{M,NTuple{N,T}}
 end
 
-"Canonical rank three tensor with element type `T`"
-immutable Ar3{N,M,P,T} <: FixedArray3{N,M,P,T}
+"""
+    FArray3{N,M,P,T}
+
+Generic rank three `N×M×P` tensor with element type `T`
+"""
+immutable FArray3{N,M,P,T} <: FixedArray3{N,M,P,T}
     values::NTuple{P,NTuple{M,NTuple{N,T}}}
 end
 
-"Canonical rank four tensor with element type `T`"
-immutable Ar4{N,M,P,Q,T} <: FixedArray4{N,M,P,Q,T}
+"""
+    FArray3{N,M,P,Q,T}
+
+Generic rank four `N×M×P×Q` tensor with element type `T`
+"""
+immutable FArray4{N,M,P,Q,T} <: FixedArray4{N,M,P,Q,T}
     values::NTuple{Q,NTuple{P,NTuple{M,NTuple{N,T}}}}
 end
 
@@ -28,9 +44,9 @@ end
     elseif length(sz) == 2
         return Mat{sz[1],sz[2],T}
     elseif length(sz) == 3
-        return Ar3{sz[1],sz[2],sz[3],T}
+        return FArray3{sz[1],sz[2],sz[3],T}
     elseif length(sz) == 4
-        return Ar4{sz[1],sz[2],sz[3],sz[4],T}
+        return FArray4{sz[1],sz[2],sz[3],sz[4],T}
     else
         throw(ArgumentError("No built in FixedArray type is implemented for eltype $T and size $sz"))
     end
@@ -38,7 +54,11 @@ end
 
 #-------------------------------------------------------------------------------
 # Other types
-"Generic member of an `N`-dimensional Cartesian space"
+"""
+    Point{N,T}
+
+Generic member of an `N`-dimensional Cartesian space with element type `T`
+"""
 immutable Point{N,T} <: FixedVector{N,T}
     values::NTuple{N,T}
 end

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -1,8 +1,22 @@
-@inline getindex{T <: FixedVector}(x::T, i::Union{Range, Integer}) = Tuple(x)[i]
-@inline getindex{T <: FixedVectorNoTuple}(x::T, i::Integer) = getfield(x, i)
+# Multidimensional indexing
+@inline Base.getindex(A::FixedArray1, i::Int) = Tuple(A)[i]
+@inline Base.getindex(A::FixedArray2, i::Int, j::Int) = Tuple(A)[j][i]
+@inline Base.getindex(A::FixedArray4, i::Int, j::Int, p::Int, q::Int) = Tuple(A)[q][p][j][i]
+@inline Base.getindex(A::FixedArray5, i::Int, j::Int, p::Int, q::Int, r::Int) = Tuple(A)[r][q][p][j][i]
+
+# Linear indexing
+@inline Base.getindex{N,M}(A::FixedArray2{N,M}, i::Int) = A[ind2sub((N,M), i)...]
+@inline Base.getindex{N,M,P}(A::FixedArray3{N,M,P}, i::Int) = A[ind2sub((N,M,P), i)...]
+@inline Base.getindex{N,M,P,Q}(A::FixedArray4{N,M,P,Q}, i::Int) = A[ind2sub((N,M,P,Q), i)...]
+@inline Base.getindex{N,M,P,Q,R}(A::FixedArray5{N,M,P,Q,R}, i::Int) = A[ind2sub((N,M,P,Q,R), i)...]
+
+@inline Base.getindex(A::FixedVectorNoTuple, i::Int) = getfield(A, i)
+
+# Stuff with Range which should probably be deprecated due to inherent type instability
+@inline getindex{T <: FixedVector}(x::T, i::Range) = Tuple(x)[i]
 @inline getindex{N, M, T}(a::Mat{N, M, T}, i::Range, j::Int) = ntuple(IndexFunc(a, j), Val{length(i)})::NTuple{length(i), T}
-@inline getindex{N, M, T}(a::Mat{N, M, T}, i::Int, j::Union{Range, Int}) = Tuple(a)[j][i]
-@inline getindex{N, M, T}(a::Mat{N, M, T}, i::Int) = a[ind2sub((N,M), i)...]
+@inline getindex{N, M, T}(a::Mat{N, M, T}, i::Int, j::Range) = Tuple(a)[j][i]
+
 @inline getindex(A::FixedArray, I::Tuple) = map(IndexFunctor(A), I)
 
 @inline setindex(a::FixedArray, value, index::Int...) = map(SetindexFunctor(a, value, index), typeof(a))
@@ -27,6 +41,8 @@
 @inline crow{R, T}(a::Mat{R, 4, T}, j::Int) = (Tuple(a)[1][j]', Tuple(a)[2][j]', Tuple(a)[3][j]', Tuple(a)[4][j]',)
 
 
+#-------------------------------------------------------------------------------
+# @fslice implementation
 # Unified slicing along combinations of fixed and variable dimensions
 
 "Get index of a field with `name` in type `T`.  Should this be in Base?"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -68,16 +68,19 @@ end
 
 context("core") do
     context("ndims") do
-        @fact ndims(Ar3) --> 3
+        @fact ndims(FArray4) --> 4
+        @fact ndims(FArray3) --> 3
         @fact ndims(Mat) --> 2
         @fact ndims(Vec) --> 1
         @fact ndims(Vec(1,2,3)) --> 1
 
-        @fact ndims(Ar3{3,3,3}) --> 3
+        @fact ndims(FArray4{3,3,3,3}) --> 4
+        @fact ndims(FArray3{3,3,3}) --> 3
         @fact ndims(Mat{3,3}) --> 2
         @fact ndims(Vec{3}) --> 1
 
-        @fact ndims(Ar3{3,3,3,Int}) --> 3
+        @fact ndims(FArray4{3,3,3,3,Int}) --> 4
+        @fact ndims(FArray3{3,3,3,Int}) --> 3
         @fact ndims(Mat{3,3,Int}) --> 2
         @fact ndims(Vec{3,Int}) --> 1
     end
@@ -92,6 +95,10 @@ context("core") do
         @fact size_or(Vec{4,Float32}, nothing) --> (4,)
         @fact size_or(FixedArray, nothing) --> nothing
 
+        @fact size_or(FArray3{2,3,4}, nothing) --> (2,3,4)
+        @fact size_or(FArray3{2,3,4,Int}, nothing) --> (2,3,4)
+        @fact size_or(FArray4{2,3,4,5}, nothing) --> (2,3,4,5)
+        @fact size_or(FArray4{2,3,4,5,Int}, nothing) --> (2,3,4,5)
     end
     context("eltype_or") do
         @fact eltype_or(Mat, nothing) --> nothing
@@ -262,8 +269,8 @@ context("Constructor ") do
         @fact typeof(rand(Mat4d, -20f0:0.192f0:230f0)) --> Mat4d
         @fact typeof(rand(Mat{4,21,Float32}, -20f0:0.192f0:230f0)) --> Mat{4,21,Float32}
 
-        x = rand(Ar3{4,4,4, Float32})
-        @fact typeof(x) --> Ar3{4,4,4, Float32}
+        x = rand(FArray3{4,4,4, Float32})
+        @fact typeof(x) --> FArray3{4,4,4, Float32}
         @fact eltype(x) --> Float32
         @fact size(x) --> (4,4,4)
         @fact typeof(rand(Vec4d, 5,5)) --> Matrix{Vec4d}

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,9 +9,6 @@ import FixedSizeArrays: similar_type
 immutable Normal{N, T} <: FixedVector{N, T}
     values::NTuple{N, T}
 end
-immutable D3{N1, N2, N3, T} <: FixedArray{T, 3, Tuple{N1, N2, N3}}
-    values::NTuple{N1, NTuple{N2, NTuple{N3, T}}}
-end
 immutable RGB{T} <: FixedVectorNoTuple{3, T}
     r::T
     g::T
@@ -71,16 +68,16 @@ end
 
 context("core") do
     context("ndims") do
-        @fact ndims(D3) --> 3
+        @fact ndims(Ar3) --> 3
         @fact ndims(Mat) --> 2
         @fact ndims(Vec) --> 1
         @fact ndims(Vec(1,2,3)) --> 1
 
-        @fact ndims(D3{3,3,3}) --> 3
+        @fact ndims(Ar3{3,3,3}) --> 3
         @fact ndims(Mat{3,3}) --> 2
         @fact ndims(Vec{3}) --> 1
 
-        @fact ndims(D3{3,3,3,Int}) --> 3
+        @fact ndims(Ar3{3,3,3,Int}) --> 3
         @fact ndims(Mat{3,3,Int}) --> 2
         @fact ndims(Vec{3,Int}) --> 1
     end
@@ -265,8 +262,8 @@ context("Constructor ") do
         @fact typeof(rand(Mat4d, -20f0:0.192f0:230f0)) --> Mat4d
         @fact typeof(rand(Mat{4,21,Float32}, -20f0:0.192f0:230f0)) --> Mat{4,21,Float32}
 
-        x = rand(D3{4,4,4, Float32})
-        @fact typeof(x) --> D3{4,4,4, Float32}
+        x = rand(Ar3{4,4,4, Float32})
+        @fact typeof(x) --> Ar3{4,4,4, Float32}
         @fact eltype(x) --> Float32
         @fact size(x) --> (4,4,4)
         @fact typeof(rand(Vec4d, 5,5)) --> Matrix{Vec4d}


### PR DESCRIPTION
~~WIP!  Do not merge!~~

Upstream 0.5 changes seem to have broken FixedArray in a pretty fundamental way ( #137 #138 https://github.com/JuliaLang/julia/issues/17247 )

I started trying to address the complete breakage in 0.5 by rethinking how the core type inheritance is arranged.  There's a lot of things commented out and broken here which will need to be cleaned up later, but I'm throwing this up here for discussion.

The basic idea is that only low-dimensional fixed arrays are much use in practice since there's already a fairly strong assumption about stack allocation and loop unrolling in the existing code which only makes sense for a few elements.  Given this assumption, it's probably ok to have an upper bound on the dimensionality:

``` julia
abstract FixedArray{T,D} <: AbstractArray{T,D}  # No fixed extents present in the base type

abstract FixedArray1{N,T}       <: FixedArray{T,1}  # length N vector
abstract FixedArray2{N,M,T}     <: FixedArray{T,2}  # NxM matrix
abstract FixedArray3{N,M,P,T}   <: FixedArray{T,3}  # NxMxP tensor
# ... Up to some MaxD dimensional tensors
```

Doing it this way means you can dispatch on either the dimensionality using `FixedArray{T,D}`, or the exact D-dimensional shape using `FixedArrayD{N1,N2,N3,...,T}`.

~~As part of the experiment, I'm seeing what happens if I make FixedArray a subtype of AbstractArray.~~ I ran out of steam on this - another time maybe.
