### PR TITLE
Reduced code generation in mat*vec and mat*mat multiply

### DIFF
--- a/src/functors.jl
+++ b/src/functors.jl
@@ -45,6 +45,12 @@ immutable IndexFunc{T} <: Functor{1}
 end
 @compat (a::IndexFunc{T}){T}(j) = a.arg[a.i,j]
 
+immutable CIndexFunc{T} <: Functor{1}
+    arg::T
+    i::Int
+end
+@compat (a::CIndexFunc{T}){T}(j) = a.arg[a.i,j]'
+
 
 immutable CRowFunctor{M}
     mat::M

--- a/src/indexing.jl
+++ b/src/indexing.jl
@@ -20,7 +20,7 @@
 
 
 # the columns of the ctranspose are the complex conjugate rows
-@inline crow{R, C, T}(a::Mat{R, C, T}, j::Int) = ntuple(IndexFunc(a, j)', Val{C})::NTuple{C, T}
+@inline crow{R, C, T}(a::Mat{R, C, T}, j::Int) = ntuple(CIndexFunc(a, j), Val{C})::NTuple{C, T}
 @inline crow{R, T}(a::Mat{R, 1, T}, j::Int) = (Tuple(a)[1][j]',)
 @inline crow{R, T}(a::Mat{R, 2, T}, j::Int) = (Tuple(a)[1][j]', Tuple(a)[2][j]')
 @inline crow{R, T}(a::Mat{R, 3, T}, j::Int) = (Tuple(a)[1][j]', Tuple(a)[2][j]', Tuple(a)[3][j]')

--- a/src/ops.jl
+++ b/src/ops.jl
@@ -179,12 +179,14 @@ end
     A[9]  * A[2]   * A[7]  * A[16] - A[1] * A[10] * A[7]  * A[16]  -
     A[5]  * A[2]   * A[11] * A[16] + A[1] * A[6]  * A[11] * A[16]
 )
+det(A::FixedMatrix) = det(Matrix(A))
 
 
 trace(A::FixedMatrix{1,1}) = A[1,1]
 trace(A::FixedMatrix{2,2}) = A[1,1] + A[2,2]
 trace(A::FixedMatrix{3,3}) = A[1,1] + A[2,2] + A[3,3]
 trace(A::FixedMatrix{4,4}) = A[1,1] + A[2,2] + A[3,3] + A[4,4]
+trace(A::FixedMatrix) = trace(Matrix(A))
 
 \{m,n,T1,T2}(mat::Mat{m,n,T1}, v::Vec{n,T2}) = inv(mat)*v
 
@@ -213,7 +215,6 @@ end
     )
 end
 
-
 @inline function inv{T}(A::Mat{4, 4, T})
     determinant = det(A)
     @inbounds return Mat{4, 4, T}(
@@ -241,6 +242,7 @@ end
     )
 end
 
+inv(A::FixedMatrix) = typeof(A)(inv(Matrix(A)))
 
 lyap{T}(a::Mat{1, 1, T}, c::Mat{1, 1, T}) = Mat{1,1,T}(lyap(a[1,1],c[1,1]))
 function lyap{T}(a::Mat{2, 2, T}, c::Mat{2, 2, T})

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1045,6 +1045,11 @@ context("Matrix Math") do
         @fact v1*v2' --> Vector(v1)*Vector(v2)'
     end
 
+    context("Large matrix multiply") do
+        M = rand(9,9)
+        v = rand(9)
+        @fact isapprox(Mat(M)*Vec(v), M*v) --> true
+    end
 end
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -904,7 +904,7 @@ context("Matrix") do
     @fact b --> Mat([1,2,3,4]'')
 end
 context("Matrix Math") do
-	for i=1:4, j=1:4
+	for i=1:5, j=1:5
 		v = rand(j)
 		m = rand(i,j)
 		m2 = rand(i,j)


### PR DESCRIPTION
Heuristic thresholds to limit the size of generated expressions in
`mat*mat` and `mat*vec` loop unrolling.  The generated machine code still
isn't necessarily good here, but this improves compile times to
something acceptable in 0.4.

In julia 0.5 with `-O` the fully unrolled 4x4 multiplication does come out looking pretty nice with a lot of simd instructions being used.  Needs real benchmarking though.

@awbsmith @andyferris 
