### PR TITLE
Fix chol warning

### DIFF
--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -5,7 +5,10 @@ using Compat
 
 importall Base
 import Base.LinAlg.chol!
-import Base.LinAlg._chol!
+
+if VERSION >= v"0.5.0-dev+4677"
+    import Base.LinAlg._chol!
+end
 
 
 # for 0.5 and 0.4 compat, use our own functor type

--- a/src/FixedSizeArrays.jl
+++ b/src/FixedSizeArrays.jl
@@ -14,10 +14,6 @@ end
 # for 0.5 and 0.4 compat, use our own functor type
 abstract Functor{N}
 
-if VERSION <= v"0.5.0"
-    supertype(x) = super(x)
-end
-
 if VERSION < v"0.5.0-dev+698"
     macro pure(ex)
         esc(ex)


### PR DESCRIPTION
See #148 .  Also use Compat for `supertype()` instead of doing it ourselves (incorrectly at that!)
