### PR TITLE
Adds norm(v,p) for FixedVector

### DIFF
--- a/src/ops.jl
+++ b/src/ops.jl
@@ -157,6 +157,15 @@ end
 @inline norm{N, T}(a::FixedVector{N, T})     = sqrt(dot(a,a))
 @inline normalize{FSA <: FixedArray}(a::FSA) = a / norm(a)
 
+function norm{N, T}(a::FixedVector{N, T}, p)
+    isinf(p) && return maxabs(a)
+    ret = abs(a[1])^p
+    for k = 2:N
+        ret += abs(a[k])^p
+    end
+    ret^(1/p)
+end
+
 function Base.isnan(p::FixedArray)
     for elem in p
         isnan(elem) && return true

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -700,6 +700,9 @@ context("Ops") do
     context("vector norm+cross product") do
 
         @fact norm(Vec3d(1.0,2.0,2.0)) --> 3.0
+        @fact norm(Vec3d(1.0,2.0,2.0),2) --> 3.0
+        @fact norm(Vec3d(1.0,2.0,2.0),Inf) --> 2.0
+        @fact norm(Vec3d(1.0,2.0,2.0),1) --> 5.0
 
         # cross product
         @fact cross(v1,v2) --> Vec3d(-7.0,14.0,-7.0)


### PR DESCRIPTION
norm(Vec(1,2),1) and norm(Vec(1,2),Inf) were not implemented, so this fixes that issue.
